### PR TITLE
[codex] Add cc-switch sync and Claude config editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ xcuserdata/
 *.xccheckout
 DerivedData/
 .derived-data/
+.derivedData/
 build/
 *.moved-aside
 *.hmap

--- a/AIUsage/Models/AppState.swift
+++ b/AIUsage/Models/AppState.swift
@@ -182,10 +182,16 @@ class AppState: ObservableObject {
             return
         }
 
+        bringMainWindowToFront()
+    }
+
+    func bringMainWindowToFront() {
         NSApp.activate(ignoringOtherApps: true)
         let candidateWindows = NSApp.windows.filter { !($0 is NSPanel) }
         let window = candidateWindows.max(by: { $0.frame.width < $1.frame.width }) ?? candidateWindows.first
+        window?.orderFrontRegardless()
         window?.makeKeyAndOrderFront(nil)
+        NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
     }
 
     @MainActor

--- a/AIUsage/Models/NodeProfile.swift
+++ b/AIUsage/Models/NodeProfile.swift
@@ -1,6 +1,48 @@
 import Foundation
 import QuotaBackend
 
+enum CommonConfigMode: String, Codable, CaseIterable {
+    case followGlobal
+    case alwaysMerge
+    case neverMerge
+
+    var label: String {
+        switch self {
+        case .followGlobal: return AppSettings.shared.t("Follow Global", "跟随全局")
+        case .alwaysMerge: return AppSettings.shared.t("Always Merge", "始终合并")
+        case .neverMerge: return AppSettings.shared.t("Never Merge", "从不合并")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .followGlobal:
+            return AppSettings.shared.t(
+                "Use the global common config switch.",
+                "使用全局通用配置开关。"
+            )
+        case .alwaysMerge:
+            return AppSettings.shared.t(
+                "Merge common config for this node even if the global switch is off.",
+                "即使全局开关关闭，也为该节点合并通用配置。"
+            )
+        case .neverMerge:
+            return AppSettings.shared.t(
+                "Do not merge common config for this node.",
+                "该节点不合并通用配置。"
+            )
+        }
+    }
+
+    func shouldMerge(globalEnabled: Bool) -> Bool {
+        switch self {
+        case .followGlobal: return globalEnabled
+        case .alwaysMerge: return true
+        case .neverMerge: return false
+        }
+    }
+}
+
 // MARK: - Node Profile
 // Each node profile is a standalone JSON file at ~/.config/aiusage/profiles/<id>.json.
 // The file contains a `_metadata` wrapper (proxy config, name, timestamps) alongside
@@ -255,6 +297,7 @@ struct ProxySettings: Codable, Equatable {
     var enableModelAliasMapping: Bool?
     var enableHTTPS: Bool?
     var httpsPort: Int?
+    var commonConfigMode: CommonConfigMode?
 
     /// Codex 专用：该节点的额外 TOML 顶层键（如 model_reasoning_effort、request_max_retries）。
     /// 激活时与全局通用配置按顶层键合并（节点键覆盖全局），注入受管理 BASE 块。可选以兼容旧档。
@@ -339,6 +382,7 @@ struct ProxySettings: Codable, Equatable {
         anthropicBaseURL: String, anthropicAPIKey: String, usePassthroughProxy: Bool,
         enableModelAliasMapping: Bool = false,
         enableHTTPS: Bool? = nil, httpsPort: Int? = nil,
+        commonConfigMode: CommonConfigMode? = nil,
         extraTOML: String? = nil
     ) {
         self.host = host
@@ -357,6 +401,7 @@ struct ProxySettings: Codable, Equatable {
         self.enableModelAliasMapping = enableModelAliasMapping
         self.enableHTTPS = enableHTTPS
         self.httpsPort = httpsPort
+        self.commonConfigMode = commonConfigMode
         self.extraTOML = extraTOML
     }
 
@@ -372,6 +417,10 @@ struct ProxySettings: Codable, Equatable {
         nodeType == .openaiProxy
             || nodeType == .codexProxy
             || (nodeType == .anthropicDirect && usePassthroughProxy)
+    }
+
+    func shouldMergeClaudeCommonConfig(globalEnabled: Bool) -> Bool {
+        (commonConfigMode ?? .followGlobal).shouldMerge(globalEnabled: globalEnabled)
     }
 
     func pricingForModel(_ model: String) -> ProxyConfiguration.ModelPricing? {

--- a/AIUsage/Services/ProxyRuntimeService.swift
+++ b/AIUsage/Services/ProxyRuntimeService.swift
@@ -289,6 +289,18 @@ final class ProxyRuntimeService {
         try await startProxy(config)
     }
 
+    /// Starts a proxy for a one-off connectivity test. Returns true when this call started it.
+    func startProxyForConnectivityTest(for config: ProxyConfiguration) async throws -> Bool {
+        if isProxyRunning(config.id) { return false }
+        try await startProxy(config)
+        return true
+    }
+
+    func stopProxyForConnectivityTest(for config: ProxyConfiguration, startedByTest: Bool) {
+        guard startedByTest else { return }
+        stopProxy(config)
+    }
+
     /// Stop a proxy-only process without touching settings.json or backup.
     func stopProxyOnly(for config: ProxyConfiguration) {
         stopProxy(config)

--- a/AIUsage/ViewModels/NodeProfileStore.swift
+++ b/AIUsage/ViewModels/NodeProfileStore.swift
@@ -2,6 +2,8 @@ import Foundation
 import SwiftUI
 import Combine
 import os.log
+import SQLite3
+import QuotaBackend
 
 // MARK: - Node Profile Store
 // File-based persistence for NodeProfile objects. Each profile is a standalone JSON file
@@ -191,6 +193,7 @@ class NodeProfileStore: ObservableObject {
         var skipped: Int = 0
         var importedGlobalConfig = false
         var importedCodexGlobalConfig = false
+        var skippedGlobalConfig = false
         var errors: [String] = []
     }
 
@@ -261,6 +264,67 @@ class NodeProfileStore: ObservableObject {
             } catch {
                 result.failed += 1
                 result.errors.append("\(fileURL.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - cc-switch Import
+
+    func importCCSwitchClaudeProfiles(dbPath: String? = nil) -> ImportResult {
+        let path = dbPath ?? Self.defaultCCSwitchDBPath
+        var result = ImportResult()
+
+        guard fileManager.fileExists(atPath: path) else {
+            result.failed = 1
+            result.errors.append("cc-switch database not found: \(path)")
+            return result
+        }
+
+        guard let db = Self.openReadonlySQLiteDB(at: path) else {
+            result.failed = 1
+            result.errors.append("failed to open cc-switch database")
+            return result
+        }
+        defer { sqlite3_close(db) }
+
+        let rows = Self.loadCCSwitchClaudeRows(db: db)
+        if rows.isEmpty {
+            result.skipped = 0
+            result.errors.append("no cc-switch Claude providers found")
+            return result
+        }
+
+        var reservedPorts = Set<Int>()
+        let importDate = Date()
+        for row in rows {
+            do {
+                let port = nextAvailablePort(startingAt: 4320, reserving: reservedPorts)
+                reservedPorts.insert(port)
+                let profile = try Self.makeProfile(from: row, port: port, importDate: importDate)
+                if save(profile) {
+                    result.succeeded += 1
+                } else {
+                    result.failed += 1
+                    result.errors.append("\(row.name): save failed")
+                }
+            } catch {
+                result.failed += 1
+                result.errors.append("\(row.name): \(error.localizedDescription)")
+            }
+        }
+
+        if let commonSettings = Self.loadCCSwitchClaudeCommonConfig(db: db), !commonSettings.isEmpty {
+            if globalConfig.settings.isEmpty {
+                globalConfig = GlobalConfig(enabled: true, settings: commonSettings)
+                if saveGlobalConfig() {
+                    result.importedGlobalConfig = true
+                } else {
+                    result.errors.append("failed to save cc-switch common config")
+                }
+            } else {
+                result.skippedGlobalConfig = true
             }
         }
 
@@ -438,15 +502,204 @@ class NodeProfileStore: ObservableObject {
         }
     }
 
+    private struct CCSwitchClaudeRow {
+        var id: String
+        var name: String
+        var settingsConfig: [String: Any]
+        var isCurrent: Bool
+        var createdAtMs: Int64?
+        var meta: [String: Any]
+    }
+
+    private enum CCSwitchImportError: LocalizedError {
+        case invalidSettings
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidSettings:
+                return "invalid cc-switch settings JSON"
+            }
+        }
+    }
+
+    private static var defaultCCSwitchDBPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return (home as NSString).appendingPathComponent(".cc-switch/cc-switch.db")
+    }
+
+    private static func openReadonlySQLiteDB(at path: String) -> OpaquePointer? {
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(path, &db, flags, nil) == SQLITE_OK else {
+            if let db { sqlite3_close(db) }
+            return nil
+        }
+        return db
+    }
+
+    private static func loadCCSwitchClaudeRows(db: OpaquePointer) -> [CCSwitchClaudeRow] {
+        let sql = """
+        SELECT id, name, settings_config, is_current, created_at, meta
+        FROM providers
+        WHERE app_type = 'claude'
+        ORDER BY sort_index, name
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+
+        var rows: [CCSwitchClaudeRow] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id = sqliteText(stmt, 0) ?? UUID().uuidString
+            let name = sqliteText(stmt, 1)?.nilIfBlank ?? "cc-switch Claude"
+            let settingsText = sqliteText(stmt, 2) ?? "{}"
+            let metaText = sqliteText(stmt, 5) ?? "{}"
+            let settings = jsonObject(from: settingsText) ?? [:]
+            let meta = jsonObject(from: metaText) ?? [:]
+            let createdAt = sqlite3_column_type(stmt, 4) == SQLITE_NULL ? nil : sqlite3_column_int64(stmt, 4)
+            rows.append(CCSwitchClaudeRow(
+                id: id,
+                name: name,
+                settingsConfig: settings,
+                isCurrent: sqlite3_column_int(stmt, 3) == 1,
+                createdAtMs: createdAt,
+                meta: meta
+            ))
+        }
+        return rows
+    }
+
+    private static func loadCCSwitchClaudeCommonConfig(db: OpaquePointer) -> [String: Any]? {
+        let sql = "SELECT value FROM settings WHERE key = 'common_config_claude' LIMIT 1"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let text = sqliteText(stmt, 0) else {
+            return nil
+        }
+        return jsonObject(from: text)
+    }
+
+    private static func makeProfile(
+        from row: CCSwitchClaudeRow,
+        port: Int,
+        importDate: Date
+    ) throws -> NodeProfile {
+        var settings = row.settingsConfig
+        var env = settings["env"] as? [String: Any] ?? [:]
+
+        let upstreamBaseURL = stringValue(env["ANTHROPIC_BASE_URL"]) ?? "https://api.anthropic.com"
+        let upstreamKey = stringValue(env["ANTHROPIC_AUTH_TOKEN"]) ?? stringValue(env["ANTHROPIC_API_KEY"]) ?? ""
+        let defaultModel = stringValue(env["ANTHROPIC_MODEL"])
+            ?? stringValue(settings["model"])
+            ?? stringValue(env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
+            ?? ""
+        let opus = stringValue(env["ANTHROPIC_DEFAULT_OPUS_MODEL"]) ?? defaultModel
+        let sonnet = stringValue(env["ANTHROPIC_DEFAULT_SONNET_MODEL"]) ?? defaultModel
+        let haiku = stringValue(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"]) ?? defaultModel
+
+        env["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:\(port)"
+        env["ANTHROPIC_AUTH_TOKEN"] = upstreamKey
+        if !opus.isEmpty { env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus }
+        if !sonnet.isEmpty { env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet }
+        if !haiku.isEmpty { env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku }
+        settings["env"] = env
+        settings["$schema"] = settings["$schema"] ?? "https://json.schemastore.org/claude-code-settings.json"
+        if !defaultModel.isEmpty { settings["model"] = defaultModel }
+
+        let commonMode: CommonConfigMode?
+        if let enabled = boolValue(row.meta["commonConfigEnabled"]) ?? boolValue(row.meta["common_config_enabled"]) {
+            commonMode = enabled ? .alwaysMerge : .neverMerge
+        } else {
+            commonMode = .followGlobal
+        }
+
+        let proxy = ProxySettings(
+            host: "127.0.0.1",
+            port: port,
+            allowLAN: false,
+            upstreamBaseURL: "https://api.openai.com",
+            openAIUpstreamAPI: .chatCompletions,
+            upstreamAPIKey: "",
+            expectedClientKey: "",
+            maxOutputTokens: 0,
+            defaultModel: defaultModel,
+            modelMapping: ProxyConfiguration.ModelMapping(
+                bigModel: .init(name: opus),
+                middleModel: .init(name: sonnet),
+                smallModel: .init(name: haiku)
+            ),
+            anthropicBaseURL: upstreamBaseURL,
+            anthropicAPIKey: upstreamKey,
+            usePassthroughProxy: true,
+            enableModelAliasMapping: false,
+            enableHTTPS: false,
+            httpsPort: nil,
+            commonConfigMode: commonMode
+        )
+
+        let createdAt = row.createdAtMs.flatMap { dateFromCCSwitchTimestamp($0) } ?? importDate
+        let metadata = NodeProfile.Metadata(
+            id: UUID().uuidString,
+            name: "\(row.name) (cc-switch)",
+            nodeType: .anthropicDirect,
+            createdAt: createdAt,
+            lastUsedAt: row.isCurrent ? importDate : nil,
+            sortOrder: Int.max,
+            proxy: proxy
+        )
+        return NodeProfile(metadata: metadata, settings: settings)
+    }
+
+    private static func sqliteText(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
+        guard let cString = sqlite3_column_text(stmt, index) else { return nil }
+        return String(cString: cString)
+    }
+
+    private static func jsonObject(from text: String) -> [String: Any]? {
+        guard let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        return string.trimmingCharacters(in: .whitespacesAndNewlines).nilIfBlank
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        if let bool = value as? Bool { return bool }
+        if let number = value as? NSNumber { return number.boolValue }
+        if let string = value as? String {
+            switch string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "true", "1", "yes": return true
+            case "false", "0", "no": return false
+            default: return nil
+            }
+        }
+        return nil
+    }
+
+    private static func dateFromCCSwitchTimestamp(_ timestamp: Int64) -> Date? {
+        guard timestamp > 0 else { return nil }
+        if timestamp > 10_000_000_000 {
+            return Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
+        }
+        return Date(timeIntervalSince1970: Double(timestamp))
+    }
+
     // MARK: - Helpers
 
     private func filePath(for id: String) -> String {
         (Self.profilesDirectory as NSString).appendingPathComponent("\(id).json")
     }
 
-    private func nextAvailablePort() -> Int {
-        let usedPorts = Set(profiles.map(\.metadata.proxy.port))
-        var port = 8080
+    func nextAvailablePort(startingAt startPort: Int = 8080, reserving reservedPorts: Set<Int> = []) -> Int {
+        let usedPorts = Set(profiles.map(\.metadata.proxy.port)).union(reservedPorts)
+        var port = startPort
         while usedPorts.contains(port) { port += 1 }
         return port
     }

--- a/AIUsage/ViewModels/ProxyViewModel+ProxyOnlyMode.swift
+++ b/AIUsage/ViewModels/ProxyViewModel+ProxyOnlyMode.swift
@@ -130,7 +130,7 @@ extension ProxyViewModel {
         }
 
         let finalSettings: [String: Any]
-        if profileStore.globalConfig.enabled {
+        if profile.metadata.proxy.shouldMergeClaudeCommonConfig(globalEnabled: profileStore.globalConfig.enabled) {
             finalSettings = GlobalConfig.deepMerge(
                 base: profileStore.globalConfig.settings,
                 override: profile.settings

--- a/AIUsage/ViewModels/ProxyViewModel+ProxyServer.swift
+++ b/AIUsage/ViewModels/ProxyViewModel+ProxyServer.swift
@@ -144,7 +144,7 @@ extension ProxyViewModel {
 
         if let profile = profileStore.profile(for: config.id) {
             let finalSettings: [String: Any]
-            if profileStore.globalConfig.enabled {
+            if profile.metadata.proxy.shouldMergeClaudeCommonConfig(globalEnabled: profileStore.globalConfig.enabled) {
                 finalSettings = GlobalConfig.deepMerge(
                     base: profileStore.globalConfig.settings,
                     override: profile.settings
@@ -195,6 +195,152 @@ extension ProxyViewModel {
 
     func isProxyRunning(_ configId: String) -> Bool {
         runtimeService.isProxyRunning(configId)
+    }
+
+    func testConnectivity(_ id: String) async {
+        guard let config = configurations.first(where: { $0.id == id }),
+              !config.nodeType.isCodex else { return }
+        guard !connectivityTestStates[id, default: .init()].isTesting else { return }
+
+        connectivityTestStates[id] = ProxyConnectivityTestState(isTesting: true, lastSucceeded: nil, message: nil)
+        defer {
+            var state = connectivityTestStates[id, default: .init()]
+            state.isTesting = false
+            connectivityTestStates[id] = state
+        }
+
+        let startedByTest: Bool
+        do {
+            if config.needsProxyProcess {
+                startedByTest = try await runtimeService.startProxyForConnectivityTest(for: config)
+            } else {
+                startedByTest = false
+            }
+        } catch {
+            let message = sanitizedConnectivityMessage(error.localizedDescription)
+            connectivityTestStates[id] = ProxyConnectivityTestState(isTesting: false, lastSucceeded: false, message: message)
+            connectivityTestMessage = AppSettings.shared.t(
+                "Connectivity test failed for \"\(config.name)\": \(message)",
+                "节点「\(config.name)」连通性测试失败：\(message)"
+            )
+            return
+        }
+
+        defer {
+            runtimeService.stopProxyForConnectivityTest(for: config, startedByTest: startedByTest)
+        }
+
+        do {
+            let message = try await performClaudeConnectivityRequest(config)
+            connectivityTestStates[id] = ProxyConnectivityTestState(isTesting: false, lastSucceeded: true, message: message)
+            connectivityTestMessage = AppSettings.shared.t(
+                "Connectivity test passed for \"\(config.name)\". \(message)",
+                "节点「\(config.name)」连通性测试通过。\(message)"
+            )
+        } catch {
+            let message = sanitizedConnectivityMessage(error.localizedDescription)
+            connectivityTestStates[id] = ProxyConnectivityTestState(isTesting: false, lastSucceeded: false, message: message)
+            connectivityTestMessage = AppSettings.shared.t(
+                "Connectivity test failed for \"\(config.name)\": \(message)",
+                "节点「\(config.name)」连通性测试失败：\(message)"
+            )
+        }
+    }
+
+    private func performClaudeConnectivityRequest(_ config: ProxyConfiguration) async throws -> String {
+        let baseURL: String
+        let apiKey: String
+        if config.needsProxyProcess {
+            baseURL = config.displayURL
+            apiKey = config.effectiveClientKey
+        } else {
+            baseURL = config.anthropicBaseURL
+            apiKey = config.anthropicAPIKey
+        }
+
+        guard let url = URL(string: claudeMessagesEndpoint(baseURL: baseURL)) else {
+            throw URLError(.badURL)
+        }
+
+        let model = [
+            config.defaultModel,
+            config.modelMapping.middleModel.name,
+            config.modelMapping.bigModel.name,
+        ].first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } ?? "claude-sonnet-4-6"
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 8,
+            "stream": false,
+            "messages": [
+                ["role": "user", "content": "ping"]
+            ],
+        ]
+
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let start = Date()
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let text = String(data: data, encoding: .utf8) ?? HTTPURLResponse.localizedString(forStatusCode: http.statusCode)
+            throw NSError(
+                domain: "AIUsage.ProxyConnectivity",
+                code: http.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode): \(sanitizedConnectivityMessage(text))"]
+            )
+        }
+
+        return AppSettings.shared.t(
+            "HTTP \(http.statusCode), \(elapsedMs) ms",
+            "HTTP \(http.statusCode)，\(elapsedMs) ms"
+        )
+    }
+
+    private func claudeMessagesEndpoint(baseURL: String) -> String {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if trimmed.hasSuffix("/v1") {
+            return "\(trimmed)/messages"
+        }
+        if trimmed.hasSuffix("/v1/messages") {
+            return trimmed
+        }
+        return "\(trimmed)/v1/messages"
+    }
+
+    private func sanitizedConnectivityMessage(_ raw: String) -> String {
+        var text = raw
+        text = text.replacingOccurrences(
+            of: #"(?i)sk-[A-Za-z0-9_\-]{8,}"#,
+            with: "sk-••••",
+            options: .regularExpression
+        )
+        let patterns = [
+            #"(?i)(Bearer\s+)[A-Za-z0-9._~+/=\-]{8,}"#,
+            #"(?i)(ANTHROPIC_AUTH_TOKEN["':=\s]+)[^"',\s}]+"#,
+            #"(?i)(x-api-key["':=\s]+)[^"',\s}]+"#,
+        ]
+        for pattern in patterns {
+            text = text.replacingOccurrences(
+                of: pattern,
+                with: "$1••••",
+                options: .regularExpression
+            )
+        }
+        return String(text.prefix(500))
     }
 }
 

--- a/AIUsage/ViewModels/ProxyViewModel.swift
+++ b/AIUsage/ViewModels/ProxyViewModel.swift
@@ -35,6 +35,12 @@ enum ProxyRuntimeError: LocalizedError {
     }
 }
 
+struct ProxyConnectivityTestState: Equatable {
+    var isTesting: Bool = false
+    var lastSucceeded: Bool?
+    var message: String?
+}
+
 @MainActor
 class ProxyViewModel: ObservableObject {
     static let shared = ProxyViewModel()
@@ -55,6 +61,8 @@ class ProxyViewModel: ObservableObject {
     var recentLogs: [String: [ProxyRequestLog]] = [:]
     @Published var operationErrorMessage: String?
     @Published var operationInProgressConfigIds: Set<String> = []
+    @Published var connectivityTestStates: [String: ProxyConnectivityTestState] = [:]
+    @Published var connectivityTestMessage: String?
 
     struct LogCacheKey: Hashable {
         let nodeFilter: String?

--- a/AIUsage/Views/ContentView.swift
+++ b/AIUsage/Views/ContentView.swift
@@ -120,11 +120,10 @@ struct ContentView: View {
         .onAppear {
             appState.registerMainWindowPresenter { section in
                 appState.selectedSection = section
-                NSApp.activate(ignoringOtherApps: true)
                 openWindow(id: AppState.mainWindowID)
-                let candidateWindows = NSApp.windows.filter { !($0 is NSPanel) }
-                let window = candidateWindows.max(by: { $0.frame.width < $1.frame.width }) ?? candidateWindows.first
-                window?.makeKeyAndOrderFront(nil)
+                DispatchQueue.main.async {
+                    appState.bringMainWindowToFront()
+                }
             }
         }
         .sheet(item: $appState.providerPickerMode) { mode in

--- a/AIUsage/Views/JSONRawEditorView.swift
+++ b/AIUsage/Views/JSONRawEditorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import WebKit
 
 // MARK: - JSON Raw Editor View
 // Full-screen code editor for raw JSON editing of settings.json content.
@@ -9,6 +10,10 @@ import AppKit
 struct JSONRawEditorView: View {
     @Binding var jsonText: String
     @Binding var error: String?
+    var title: String = L("settings.json", "settings.json")
+    var isEditable: Bool = true
+    var showsActions: Bool = true
+    var lineMarkers: [Int: String] = [:]
     @State private var lineCount: Int = 1
     @State private var showValidationSuccess = false
 
@@ -17,7 +22,7 @@ struct JSONRawEditorView: View {
             HStack(spacing: 12) {
                 Image(systemName: "curlybraces")
                     .foregroundStyle(.secondary)
-                Text(L("settings.json", "settings.json"))
+                Text(title)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -25,27 +30,29 @@ struct JSONRawEditorView: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
 
-                Button {
-                    formatJSON()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "text.alignleft")
-                        Text(L("Format", "格式化"))
+                if showsActions {
+                    Button {
+                        formatJSON()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "text.alignleft")
+                            Text(L("Format", "格式化"))
+                        }
+                        .font(.caption.weight(.medium))
                     }
-                    .font(.caption.weight(.medium))
-                }
-                .buttonStyle(.borderless)
+                    .buttonStyle(.borderless)
 
-                Button {
-                    validateJSON()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle")
-                        Text(L("Validate", "校验"))
+                    Button {
+                        validateJSON()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle")
+                            Text(L("Validate", "校验"))
+                        }
+                        .font(.caption.weight(.medium))
                     }
-                    .font(.caption.weight(.medium))
+                    .buttonStyle(.borderless)
                 }
-                .buttonStyle(.borderless)
 
                 if showValidationSuccess {
                     HStack(spacing: 3) {
@@ -62,7 +69,12 @@ struct JSONRawEditorView: View {
 
             Divider()
 
-            JSONTextEditor(text: $jsonText, lineCount: $lineCount)
+            JSONTextEditor(
+                text: $jsonText,
+                lineCount: $lineCount,
+                isEditable: isEditable,
+                lineMarkers: lineMarkers
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let error {
@@ -122,136 +134,737 @@ struct JSONRawEditorView: View {
     }
 }
 
-// MARK: - NSTextView Wrapper
+// MARK: - Web Code Editor
 
 private struct JSONTextEditor: NSViewRepresentable {
     @Binding var text: String
     @Binding var lineCount: Int
+    var isEditable: Bool
+    var lineMarkers: [Int: String]
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        config.userContentController.add(context.coordinator, name: "editor")
 
-        textView.isEditable = true
-        textView.isSelectable = true
-        textView.allowsUndo = true
-        textView.isRichText = false
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = JSONSyntaxHighlighter.font
-        textView.textColor = .textColor
-        textView.backgroundColor = NSColor.controlBackgroundColor
-        textView.textContainerInset = NSSize(width: 12, height: 12)
-        textView.delegate = context.coordinator
-
-        context.coordinator.isUpdating = true
-        textView.string = text
-        context.coordinator.isUpdating = false
-
-        JSONSyntaxHighlighter.highlight(textView.textStorage!)
-
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = true
-        scrollView.autohidesScrollers = true
-
-        DispatchQueue.main.async {
-            lineCount = text.components(separatedBy: "\n").count
-        }
-
-        return scrollView
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.setValue(false, forKey: "drawsBackground")
+        context.coordinator.webView = webView
+        webView.loadHTMLString(Self.html, baseURL: nil)
+        return webView
     }
 
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.parent = self
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-        if textView.string != text {
-            let range = textView.selectedRange()
-            context.coordinator.isUpdating = true
-            textView.string = text
-            context.coordinator.isUpdating = false
-            textView.setSelectedRange(NSRange(location: min(range.location, (text as NSString).length), length: 0))
-            JSONSyntaxHighlighter.highlight(textView.textStorage!)
-            DispatchQueue.main.async {
-                lineCount = text.components(separatedBy: "\n").count
-            }
-        }
+        context.coordinator.applyState()
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
 
-    class Coordinator: NSObject, NSTextViewDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         var parent: JSONTextEditor
-        var isUpdating = false
+        weak var webView: WKWebView?
+        var isReady = false
+        var lastAppliedText: String?
+        var lastAppliedEditable: Bool?
+        var lastAppliedMarkers: [Int: String] = [:]
 
         init(_ parent: JSONTextEditor) {
             self.parent = parent
         }
 
-        func textDidChange(_ notification: Notification) {
-            guard !isUpdating else { return }
-            guard let textView = notification.object as? NSTextView else { return }
-            parent.text = textView.string
-            parent.lineCount = textView.string.components(separatedBy: "\n").count
-            JSONSyntaxHighlighter.highlight(textView.textStorage!)
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isReady = true
+            applyState(force: true)
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard let payload = message.body as? [String: Any],
+                  let type = payload["type"] as? String else {
+                return
+            }
+            switch type {
+            case "textChanged":
+                let nextText = payload["text"] as? String ?? ""
+                parent.text = nextText
+                parent.lineCount = payload["lineCount"] as? Int ?? nextText.components(separatedBy: "\n").count
+                lastAppliedText = nextText
+            case "lineCount":
+                parent.lineCount = payload["lineCount"] as? Int ?? parent.lineCount
+            default:
+                break
+            }
+        }
+
+        func applyState(force: Bool = false) {
+            guard isReady, let webView else { return }
+            guard force
+                    || lastAppliedText != parent.text
+                    || lastAppliedEditable != parent.isEditable
+                    || lastAppliedMarkers != parent.lineMarkers else { return }
+            lastAppliedText = parent.text
+            lastAppliedEditable = parent.isEditable
+            lastAppliedMarkers = parent.lineMarkers
+            let textLiteral = Self.javascriptString(parent.text)
+            let editableLiteral = parent.isEditable ? "true" : "false"
+            let markersLiteral = Self.javascriptObject(parent.lineMarkers)
+            webView.evaluateJavaScript("window.setEditorState(\(textLiteral), \(editableLiteral)); window.setLineMarkers(\(markersLiteral));")
+        }
+
+        private static func javascriptString(_ value: String) -> String {
+            guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+                  let arrayLiteral = String(data: data, encoding: .utf8) else {
+                return "''"
+            }
+            return "(\(arrayLiteral))[0]"
+        }
+
+        private static func javascriptObject(_ markers: [Int: String]) -> String {
+            let keyed = Dictionary(uniqueKeysWithValues: markers.map { (String($0.key), $0.value) })
+            guard let data = try? JSONSerialization.data(withJSONObject: keyed),
+                  let objectLiteral = String(data: data, encoding: .utf8) else {
+                return "{}"
+            }
+            return objectLiteral
         }
     }
 }
 
-// MARK: - JSON Syntax Highlighter
+private extension JSONTextEditor {
+    static let html = """
+    <!doctype html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <style>
+        :root {
+          color-scheme: light dark;
+          --bg: color-mix(in srgb, Canvas 94%, CanvasText 6%);
+          --panel: Canvas;
+          --text: CanvasText;
+          --muted: color-mix(in srgb, CanvasText 46%, transparent);
+          --gutter: color-mix(in srgb, CanvasText 36%, transparent);
+          --line: color-mix(in srgb, CanvasText 12%, transparent);
+          --selection: color-mix(in srgb, Highlight 34%, transparent);
+          --active-line: color-mix(in srgb, Highlight 10%, transparent);
+          --find: rgba(255, 210, 84, .46);
+          --find-active: rgba(255, 149, 0, .72);
+          --source-common: color-mix(in srgb, #3b82f6 12%, transparent);
+          --source-node: color-mix(in srgb, #10a37f 12%, transparent);
+          --source-override: color-mix(in srgb, #f59e0b 16%, transparent);
+          --key: #008c8c;
+          --string: #138a36;
+          --number: #c56a00;
+          --constant: #8e44ad;
+        }
+        html, body {
+          margin: 0;
+          width: 100%;
+          height: 100%;
+          overflow: hidden;
+          background: var(--bg);
+          color: var(--text);
+          font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+        }
+        body {
+          display: flex;
+          flex-direction: column;
+        }
+        #findBar {
+          display: none;
+          align-items: center;
+          gap: 6px;
+          min-height: 34px;
+          padding: 6px 8px;
+          border-bottom: 1px solid var(--line);
+          background: color-mix(in srgb, Canvas 92%, CanvasText 8%);
+          box-sizing: border-box;
+          font-size: 12px;
+        }
+        #findBar.visible { display: flex; }
+        #findInput {
+          flex: 1;
+          min-width: 80px;
+          height: 22px;
+          border: 1px solid var(--line);
+          border-radius: 6px;
+          padding: 0 8px;
+          background: Canvas;
+          color: CanvasText;
+          outline: none;
+          font-size: 12px;
+        }
+        #findInput:focus {
+          border-color: color-mix(in srgb, Highlight 70%, var(--line));
+          box-shadow: 0 0 0 2px color-mix(in srgb, Highlight 18%, transparent);
+        }
+        .findButton {
+          width: 24px;
+          height: 22px;
+          border: 1px solid var(--line);
+          border-radius: 6px;
+          background: Canvas;
+          color: CanvasText;
+          font-size: 12px;
+          padding: 0;
+        }
+        #findCount {
+          color: var(--muted);
+          font-variant-numeric: tabular-nums;
+          min-width: 48px;
+          text-align: right;
+        }
+        #shell {
+          position: relative;
+          flex: 1;
+          min-height: 0;
+          display: grid;
+          grid-template-columns: 48px 1fr;
+          background: var(--panel);
+        }
+        #gutterClip {
+          position: relative;
+          overflow: hidden;
+          border-right: 1px solid var(--line);
+          background: color-mix(in srgb, Canvas 88%, CanvasText 12%);
+        }
+        #gutter {
+          position: absolute;
+          left: 0;
+          right: 0;
+          top: 0;
+          padding: 12px 4px 12px 0;
+          box-sizing: border-box;
+          color: var(--gutter);
+          font: 12px/20px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+          user-select: none;
+        }
+        .gutterLine {
+          height: 20px;
+          display: grid;
+          grid-template-columns: 14px 1fr;
+          align-items: center;
+          column-gap: 3px;
+        }
+        .source-common { background: var(--source-common); }
+        .source-node { background: var(--source-node); }
+        .source-override { background: var(--source-override); }
+        .foldToggle {
+          width: 14px;
+          height: 18px;
+          border: 0;
+          padding: 0;
+          background: transparent;
+          color: var(--gutter);
+          font: 10px/18px -apple-system, BlinkMacSystemFont, sans-serif;
+          cursor: pointer;
+          opacity: .75;
+        }
+        .foldToggle:hover {
+          color: var(--text);
+          opacity: 1;
+        }
+        .foldToggle.empty {
+          cursor: default;
+          opacity: 0;
+        }
+        .lineNumber {
+          text-align: right;
+          padding-right: 3px;
+        }
+        #codeArea {
+          position: relative;
+          overflow: hidden;
+          background:
+            linear-gradient(var(--active-line), var(--active-line)) 0 12px / 100% 20px no-repeat,
+            Canvas;
+        }
+        #highlight, #input {
+          position: absolute;
+          inset: 0;
+          box-sizing: border-box;
+          margin: 0;
+          border: 0;
+          min-width: 100%;
+          min-height: 100%;
+          font: 12px/20px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+          tab-size: 2;
+          white-space: pre;
+        }
+        #lineBackgrounds {
+          position: absolute;
+          inset: 0;
+          box-sizing: border-box;
+          padding: 12px 0;
+          overflow: visible;
+          pointer-events: none;
+        }
+        .lineBackground {
+          height: 20px;
+          width: 100%;
+        }
+        #highlight {
+          overflow: visible;
+          color: var(--text);
+          pointer-events: none;
+          padding: 12px 0;
+        }
+        #input {
+          overflow: auto;
+          resize: none;
+          outline: none;
+          background: transparent;
+          padding: 12px;
+          color: transparent;
+          caret-color: var(--text);
+          -webkit-text-fill-color: transparent;
+          selection-background-color: var(--selection);
+        }
+        #input::selection {
+          background: var(--selection);
+        }
+        .readonly #input {
+          display: none;
+        }
+        .readonly #highlight {
+          overflow: auto;
+          pointer-events: auto;
+          user-select: text;
+          white-space: pre;
+        }
+        .codeLine {
+          display: block;
+          min-width: 100%;
+          width: max-content;
+          min-height: 20px;
+          padding: 0 12px;
+          box-sizing: border-box;
+        }
+        .key { color: var(--key); }
+        .string { color: var(--string); }
+        .number { color: var(--number); }
+        .constant { color: var(--constant); }
+        .match {
+          background: var(--find);
+          border-radius: 2px;
+        }
+        .match.active {
+          background: var(--find-active);
+        }
+        .foldPlaceholder {
+          color: var(--muted);
+          font-style: italic;
+        }
+      </style>
+    </head>
+    <body>
+      <div id="findBar">
+        <input id="findInput" placeholder="Find" autocomplete="off" spellcheck="false">
+        <span id="findCount">0/0</span>
+        <button class="findButton" id="prevButton" title="Previous">↑</button>
+        <button class="findButton" id="nextButton" title="Next">↓</button>
+        <button class="findButton" id="closeButton" title="Close">×</button>
+      </div>
+      <div id="shell">
+        <div id="gutterClip"><div id="gutter">1</div></div>
+        <div id="codeArea">
+          <div id="lineBackgrounds"></div>
+          <pre id="highlight"></pre>
+          <textarea id="input" spellcheck="false" autocorrect="off" autocapitalize="off"></textarea>
+        </div>
+      </div>
+      <script>
+        const input = document.getElementById('input');
+        const highlight = document.getElementById('highlight');
+        const lineBackgrounds = document.getElementById('lineBackgrounds');
+        const gutter = document.getElementById('gutter');
+        const shell = document.getElementById('shell');
+        const findBar = document.getElementById('findBar');
+        const findInput = document.getElementById('findInput');
+        const findCount = document.getElementById('findCount');
+        const prevButton = document.getElementById('prevButton');
+        const nextButton = document.getElementById('nextButton');
+        const closeButton = document.getElementById('closeButton');
+        let textValue = '';
+        let editable = true;
+        let query = '';
+        let matches = [];
+        let activeMatch = -1;
+        let applying = false;
+        let foldedRanges = new Map();
+        let foldRanges = new Map();
+        let lineMarkers = {};
+        let lineHeight = 20;
 
-enum JSONSyntaxHighlighter {
-    static let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-
-    private static let stringPattern = try! NSRegularExpression(pattern: #""(?:[^"\\]|\\.)*""#)
-    private static let numberPattern = try! NSRegularExpression(pattern: #"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?"#)
-    private static let constantPattern = try! NSRegularExpression(pattern: #"\b(?:true|false|null)\b"#)
-
-    static func highlight(_ textStorage: NSTextStorage) {
-        let text = textStorage.string
-        let fullRange = NSRange(location: 0, length: textStorage.length)
-        guard fullRange.length > 0 else { return }
-
-        textStorage.beginEditing()
-
-        textStorage.addAttribute(.foregroundColor, value: NSColor.textColor, range: fullRange)
-        textStorage.addAttribute(.font, value: font, range: fullRange)
-
-        for match in numberPattern.matches(in: text, range: fullRange) {
-            textStorage.addAttribute(.foregroundColor, value: NSColor.systemOrange, range: match.range)
+        function escapeHTML(value) {
+          return value
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;');
         }
 
-        for match in constantPattern.matches(in: text, range: fullRange) {
-            textStorage.addAttribute(.foregroundColor, value: NSColor.systemPurple, range: match.range)
+        function tokenClass(source, value, end) {
+          if (/^"(?:[^"\\\\]|\\\\.)*"$/.test(value)) {
+            let idx = end;
+            while (idx < source.length && /\\s/.test(source[idx])) idx++;
+            return source[idx] === ':' ? 'key' : 'string';
+          }
+          if (/^-?\\d/.test(value)) return 'number';
+          if (/^(true|false|null)$/.test(value)) return 'constant';
+          return '';
         }
 
-        let nsText = text as NSString
-        for match in stringPattern.matches(in: text, range: fullRange) {
-            let matchRange = match.range
-            let isKey = Self.isJSONKey(in: nsText, afterStringEnd: matchRange.location + matchRange.length)
-            textStorage.addAttribute(
-                .foregroundColor,
-                value: isKey ? NSColor.systemTeal : NSColor.systemGreen,
-                range: matchRange
-            )
+        function lineStarts(source) {
+          const starts = [0];
+          for (let i = 0; i < source.length; i++) {
+            if (source[i] === '\\n') starts.push(i + 1);
+          }
+          return starts;
         }
 
-        textStorage.endEditing()
-    }
+        function lineForIndex(starts, index) {
+          let lo = 0, hi = starts.length - 1;
+          while (lo <= hi) {
+            const mid = Math.floor((lo + hi) / 2);
+            if (starts[mid] <= index) lo = mid + 1;
+            else hi = mid - 1;
+          }
+          return Math.max(0, hi);
+        }
 
-    private static func isJSONKey(in nsText: NSString, afterStringEnd end: Int) -> Bool {
-        var idx = end
-        while idx < nsText.length {
-            let ch = nsText.character(at: idx)
-            if ch == 0x20 || ch == 0x09 || ch == 0x0A || ch == 0x0D {
-                idx += 1
-                continue
+        function rebuildFoldRanges() {
+          foldRanges.clear();
+          const starts = lineStarts(textValue);
+          const stack = [];
+          let inString = false;
+          let escape = false;
+          for (let i = 0; i < textValue.length; i++) {
+            const ch = textValue[i];
+            if (inString) {
+              if (escape) {
+                escape = false;
+              } else if (ch === '\\\\') {
+                escape = true;
+              } else if (ch === '"') {
+                inString = false;
+              }
+              continue;
             }
-            return ch == 0x3A // ':'
+            if (ch === '"') {
+              inString = true;
+            } else if (ch === '{' || ch === '[') {
+              stack.push({ ch, line: lineForIndex(starts, i) });
+            } else if (ch === '}' || ch === ']') {
+              const opener = ch === '}' ? '{' : '[';
+              for (let j = stack.length - 1; j >= 0; j--) {
+                if (stack[j].ch === opener) {
+                  const startLine = stack[j].line;
+                  const endLine = lineForIndex(starts, i);
+                  stack.splice(j);
+                  if (endLine > startLine) foldRanges.set(startLine, endLine);
+                  break;
+                }
+              }
+            }
+          }
+          for (const [start, end] of Array.from(foldedRanges.entries())) {
+            if (foldRanges.get(start) !== end) foldedRanges.delete(start);
+          }
         }
-        return false
-    }
+
+        function buildDisplay() {
+          const lines = textValue.split('\\n');
+          const output = [];
+          const rows = [];
+          for (let line = 0; line < lines.length; line++) {
+            const foldedEnd = foldedRanges.get(line);
+            const original = lines[line] ?? '';
+            if (foldedEnd !== undefined) {
+              const hiddenCount = Math.max(1, foldedEnd - line);
+              const suffix = `  … ${hiddenCount} lines folded`;
+              output.push(`${original}${suffix}`);
+              rows.push({ line, foldable: true, folded: true, placeholderStart: original.length });
+              line = foldedEnd;
+            } else {
+              output.push(original);
+              rows.push({ line, foldable: foldRanges.has(line), folded: false });
+            }
+          }
+          return { text: output.join('\\n'), rows };
+        }
+
+        function computeMatches() {
+          matches = [];
+          activeMatch = -1;
+          if (!query) return;
+          const haystack = buildDisplay().text.toLowerCase();
+          const needle = query.toLowerCase();
+          let idx = haystack.indexOf(needle);
+          while (idx !== -1) {
+            matches.push([idx, idx + needle.length]);
+            idx = haystack.indexOf(needle, idx + Math.max(needle.length, 1));
+          }
+          if (matches.length > 0) activeMatch = 0;
+        }
+
+        function splitWithMatches(source, start, end, className) {
+          let html = '';
+          let cursor = start;
+          for (let i = 0; i < matches.length; i++) {
+            const [mStart, mEnd] = matches[i];
+            if (mEnd <= start || mStart >= end) continue;
+            const beforeEnd = Math.max(cursor, Math.min(mStart, end));
+            if (beforeEnd > cursor) {
+              html += span(source.slice(cursor, beforeEnd), className);
+            }
+            const hitStart = Math.max(cursor, mStart, start);
+            const hitEnd = Math.min(mEnd, end);
+            if (hitEnd > hitStart) {
+              html += span(source.slice(hitStart, hitEnd), [className, 'match', i === activeMatch ? 'active' : ''].filter(Boolean).join(' '), i === activeMatch && hitStart === mStart ? 'activeMatch' : '');
+              cursor = hitEnd;
+            }
+          }
+          if (cursor < end) html += span(source.slice(cursor, end), className);
+          return html;
+        }
+
+        function span(value, className, id) {
+          const idAttr = id ? ` id="${id}"` : '';
+          const classAttr = className ? ` class="${className}"` : '';
+          return `<span${idAttr}${classAttr}>${escapeHTML(value)}</span>`;
+        }
+
+        function markerClass(marker) {
+          if (marker === 'C') return 'source-common';
+          if (marker === 'N') return 'source-node';
+          if (marker === 'O') return 'source-override';
+          return '';
+        }
+
+        function renderSourceSegment(source, start, end) {
+          const regex = /"(?:[^"\\\\]|\\\\.)*"|-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|\\b(?:true|false|null)\\b/g;
+          regex.lastIndex = start;
+          let html = '';
+          let cursor = start;
+          let match;
+          while ((match = regex.exec(source)) !== null) {
+            if (match.index >= end) break;
+            if (match.index > cursor) {
+              html += splitWithMatches(source, cursor, match.index, '');
+            }
+            const value = match[0];
+            const tokenEnd = Math.min(match.index + value.length, end);
+            html += splitWithMatches(source, match.index, tokenEnd, tokenClass(source, value, match.index + value.length));
+            cursor = tokenEnd;
+          }
+          if (cursor < end) html += splitWithMatches(source, cursor, end, '');
+          return html;
+        }
+
+        function renderHighlight() {
+          const display = buildDisplay();
+          const source = display.text;
+          const starts = lineStarts(source);
+          const lines = source.split('\\n');
+          let html = display.rows.map((row, index) => {
+            const start = starts[index] ?? 0;
+            const end = start + (lines[index] ?? '').length;
+            let lineHTML;
+            if (row.folded && row.placeholderStart !== undefined) {
+              const placeholderStart = Math.min(end, start + row.placeholderStart);
+              lineHTML = renderSourceSegment(source, start, placeholderStart)
+                + splitWithMatches(source, placeholderStart, end, 'foldPlaceholder');
+            } else {
+              lineHTML = renderSourceSegment(source, start, end);
+            }
+            if (lineHTML.length === 0) lineHTML = '&nbsp;';
+            return `<span class="codeLine">${lineHTML}</span>`;
+          }).join('');
+          if (html.length === 0) html = '<span></span>';
+          highlight.innerHTML = html;
+          lineBackgrounds.innerHTML = display.rows.map((row) => {
+            const marker = markerClass(lineMarkers[String(row.line + 1)] || '');
+            return `<div class="lineBackground ${marker}"></div>`;
+          }).join('');
+          if (input.value !== source) input.value = source;
+        }
+
+        function renderGutter() {
+          const display = buildDisplay();
+          const count = Math.max(1, textValue.split('\\n').length);
+          gutter.innerHTML = display.rows.map((row) => {
+            const symbol = row.foldable ? (row.folded ? '▶' : '▾') : '•';
+            const empty = row.foldable ? '' : ' empty';
+            const marker = lineMarkers[String(row.line + 1)] || '';
+            return `<div class="gutterLine ${markerClass(marker)}" data-line="${row.line}">
+              <button class="foldToggle${empty}" data-line="${row.line}" ${row.foldable ? '' : 'disabled'}>${symbol}</button>
+              <span class="lineNumber">${row.line + 1}</span>
+            </div>`;
+          }).join('');
+          window.webkit.messageHandlers.editor.postMessage({ type: 'lineCount', lineCount: count });
+        }
+
+        function render() {
+          rebuildFoldRanges();
+          renderHighlight();
+          renderGutter();
+          updateFindCount();
+          syncScroll();
+        }
+
+        function syncScroll() {
+          const top = editable ? input.scrollTop : highlight.scrollTop;
+          const left = editable ? input.scrollLeft : highlight.scrollLeft;
+          if (editable) {
+            highlight.style.transform = `translate(${-left}px, ${-top}px)`;
+          } else {
+            highlight.style.transform = 'none';
+          }
+          lineBackgrounds.style.transform = `translateY(${-top}px)`;
+          gutter.style.transform = `translateY(${-top}px)`;
+        }
+
+        function notifyChange() {
+          const lineCount = Math.max(1, textValue.split('\\n').length);
+          window.webkit.messageHandlers.editor.postMessage({ type: 'textChanged', text: textValue, lineCount });
+        }
+
+        function updateFromInput() {
+          if (applying) return;
+          if (foldedRanges.size > 0) {
+            foldedRanges.clear();
+            input.value = textValue;
+            render();
+            return;
+          }
+          textValue = input.value;
+          const previousQuery = query;
+          computeMatches();
+          if (previousQuery !== query) activeMatch = -1;
+          render();
+          notifyChange();
+        }
+
+        function setEditable(nextEditable) {
+          editable = nextEditable;
+          shell.classList.toggle('readonly', !editable);
+          input.readOnly = !editable || foldedRanges.size > 0;
+          if (editable) {
+            input.style.display = 'block';
+          }
+        }
+
+        window.setEditorState = function(nextText, nextEditable) {
+          applying = true;
+          textValue = nextText || '';
+          foldedRanges.clear();
+          input.value = textValue;
+          setEditable(!!nextEditable);
+          computeMatches();
+          render();
+          applying = false;
+        };
+
+        window.setLineMarkers = function(nextMarkers) {
+          for (const key of Object.keys(lineMarkers)) delete lineMarkers[key];
+          for (const [key, value] of Object.entries(nextMarkers || {})) lineMarkers[key] = value;
+          render();
+        };
+
+        function openFind() {
+          findBar.classList.add('visible');
+          findInput.focus();
+          findInput.select();
+        }
+
+        function closeFind() {
+          findBar.classList.remove('visible');
+          query = '';
+          matches = [];
+          activeMatch = -1;
+          render();
+          if (editable) input.focus();
+        }
+
+        function updateFindCount() {
+          findCount.textContent = matches.length === 0 ? '0/0' : `${activeMatch + 1}/${matches.length}`;
+        }
+
+        function selectMatch(direction) {
+          if (matches.length === 0) return;
+          activeMatch = (activeMatch + direction + matches.length) % matches.length;
+          render();
+          setTimeout(() => {
+            const el = document.getElementById('activeMatch');
+            if (el) el.scrollIntoView({ block: 'center', inline: 'center' });
+            syncScroll();
+          }, 0);
+        }
+
+        function clearFoldsForEditing(event) {
+          if (!editable || foldedRanges.size === 0) return false;
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') return false;
+          foldedRanges.clear();
+          input.readOnly = false;
+          input.value = textValue;
+          render();
+          event.preventDefault();
+          input.focus();
+          return true;
+        }
+
+        gutter.addEventListener('click', (event) => {
+          const button = event.target.closest('.foldToggle');
+          if (!button || button.classList.contains('empty')) return;
+          const line = Number(button.dataset.line);
+          const end = foldRanges.get(line);
+          if (end === undefined) return;
+          if (foldedRanges.has(line)) foldedRanges.delete(line);
+          else foldedRanges.set(line, end);
+          computeMatches();
+          render();
+        });
+
+        input.addEventListener('input', updateFromInput);
+        input.addEventListener('scroll', syncScroll);
+        highlight.addEventListener('scroll', syncScroll);
+        input.addEventListener('keydown', (event) => {
+          if (clearFoldsForEditing(event)) return;
+          if (event.key === 'Tab') {
+            event.preventDefault();
+            const start = input.selectionStart;
+            const end = input.selectionEnd;
+            input.setRangeText('  ', start, end, 'end');
+            updateFromInput();
+          }
+        });
+        document.addEventListener('keydown', (event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
+            event.preventDefault();
+            openFind();
+          } else if (event.key === 'Escape' && findBar.classList.contains('visible')) {
+            event.preventDefault();
+            closeFind();
+          } else if (event.key === 'Enter' && findBar.classList.contains('visible') && document.activeElement === findInput) {
+            event.preventDefault();
+            selectMatch(event.shiftKey ? -1 : 1);
+          }
+        });
+        findInput.addEventListener('input', () => {
+          query = findInput.value;
+          computeMatches();
+          render();
+          if (matches.length > 0) selectMatch(0);
+        });
+        prevButton.addEventListener('click', () => selectMatch(-1));
+        nextButton.addEventListener('click', () => selectMatch(1));
+        closeButton.addEventListener('click', closeFind);
+      </script>
+    </body>
+    </html>
+    """
 }

--- a/AIUsage/Views/ProviderDetailView.swift
+++ b/AIUsage/Views/ProviderDetailView.swift
@@ -496,12 +496,15 @@ struct ProviderDetailView: View {
     }
 
     private var copyTargetValue: String? {
-        detailAccountLabel?.nilIfBlank
-            ?? provider.accountLabel?.nilIfBlank
-            ?? provider.accountId?.nilIfBlank
-            ?? titleOverride?.nilIfBlank
-            ?? detailSubtitle?.nilIfBlank
-            ?? provider.sourceLabel.nilIfBlank
+        let candidates: [String?] = [
+            detailAccountLabel,
+            provider.accountLabel,
+            provider.accountId,
+            titleOverride,
+            detailSubtitle,
+            provider.sourceLabel
+        ]
+        return candidates.compactMap(\.nilIfBlank).first
     }
     
     

--- a/AIUsage/Views/ProxyConfigEditorView.swift
+++ b/AIUsage/Views/ProxyConfigEditorView.swift
@@ -40,6 +40,10 @@ struct ProxyConfigEditorView: View {
     @State private var fetchModelsError: String?
     @State private var jsonText: String = ""
     @State private var jsonError: String?
+    @State private var finalJSONText: String = ""
+    @State private var finalJSONError: String?
+    @State private var globalConfigDraftSettings: [String: Any]?
+    @State private var isApplyingFinalJSONEdit = false
 
     init(profile: NodeProfile? = nil) {
         if let profile {
@@ -87,7 +91,7 @@ struct ProxyConfigEditorView: View {
             Divider()
             footerBar
         }
-        .frame(width: 750, height: 800)
+        .frame(width: selectedTab == .json ? 1100 : 750, height: 800)
     }
 
     // MARK: - Header
@@ -155,7 +159,7 @@ struct ProxyConfigEditorView: View {
                 saveProfile()
             }
             .buttonStyle(.borderedProminent)
-            .disabled(!isValid)
+            .disabled(!isValid || (selectedTab == .json && finalJSONError != nil))
         }
         .padding(20)
     }
@@ -188,10 +192,132 @@ struct ProxyConfigEditorView: View {
         SettingsVisualEditorView(settings: $profile.settings)
     }
 
+    private var commonConfigSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(L("Common Config", "通用配置"))
+                .font(.headline.weight(.bold))
+
+            Picker("", selection: Binding(
+                get: { profile.metadata.proxy.commonConfigMode ?? .followGlobal },
+                set: {
+                    profile.metadata.proxy.commonConfigMode = $0
+                    refreshFinalSettingsPreview()
+                }
+            )) {
+                ForEach(CommonConfigMode.allCases, id: \.self) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Text((profile.metadata.proxy.commonConfigMode ?? .followGlobal).description)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                Image(systemName: viewModel.profileStore.globalConfig.enabled ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(viewModel.profileStore.globalConfig.enabled ? .green : .secondary)
+                Text(viewModel.profileStore.globalConfig.enabled
+                     ? L("Global common config is enabled.", "全局通用配置已开启。")
+                     : L("Global common config is disabled.", "全局通用配置已关闭。"))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            }
+
+            HStack(spacing: 8) {
+                sourceLegend(L("Common", "通用配置"), .blue)
+                sourceLegend(L("Node", "节点配置"), .green)
+                sourceLegend(L("Override", "节点覆盖"), .orange)
+                Spacer()
+            }
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(nsColor: .controlBackgroundColor)))
+    }
+
+    private func sourceLegend(_ label: String, _ color: Color) -> some View {
+        HStack(spacing: 4) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(color.opacity(0.18))
+                .frame(width: 22, height: 10)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
     // MARK: - Tab 3: JSON Editor
 
     private var jsonEditorTab: some View {
-        JSONRawEditorView(jsonText: $jsonText, error: $jsonError)
+        VStack(spacing: 12) {
+            commonConfigSection
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+            HStack(spacing: 12) {
+                JSONRawEditorView(
+                    jsonText: $jsonText,
+                    error: $jsonError,
+                    title: L("Node settings.json", "节点 settings.json")
+                )
+
+                JSONRawEditorView(
+                    jsonText: Binding(
+                        get: { finalJSONText.isEmpty ? finalSettingsPreviewText : finalJSONText },
+                        set: { applyFinalJSONEdit($0) }
+                    ),
+                    error: $finalJSONError,
+                    title: L("Layered final settings", "分层最终配置"),
+                    isEditable: true,
+                    showsActions: true,
+                    lineMarkers: finalJSONLineMarkers
+                )
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .onAppear {
+            ensureGlobalDraft()
+            refreshFinalSettingsPreview()
+        }
+        .onChange(of: jsonText) { _, _ in
+            guard selectedTab == .json, !isApplyingFinalJSONEdit else { return }
+            refreshFinalSettingsPreview()
+        }
+    }
+
+    private var finalSettingsPreviewText: String {
+        let finalSettings = shouldMergeCommonConfig
+            ? GlobalConfig.deepMerge(
+                base: currentGlobalSettings,
+                override: currentNodeSettings
+            )
+            : currentNodeSettings
+        return prettyJSONString(finalSettings)
+    }
+
+    private var currentGlobalSettings: [String: Any] {
+        globalConfigDraftSettings ?? viewModel.profileStore.globalConfig.settings
+    }
+
+    private var currentNodeSettings: [String: Any] {
+        parsedJSONSettings(from: jsonText) ?? profile.settings
+    }
+
+    private var shouldMergeCommonConfig: Bool {
+        profile.metadata.proxy.shouldMergeClaudeCommonConfig(
+            globalEnabled: viewModel.profileStore.globalConfig.enabled
+        )
+    }
+
+    private var finalJSONLineMarkers: [Int: String] {
+        lineMarkers(
+            for: finalJSONText.isEmpty ? finalSettingsPreviewText : finalJSONText,
+            global: currentGlobalSettings,
+            node: currentNodeSettings,
+            shouldMerge: shouldMergeCommonConfig
+        )
     }
 
     // MARK: - JSON Sync
@@ -200,15 +326,17 @@ struct ProxyConfigEditorView: View {
         profile.syncEnvFromProxy()
         jsonText = profile.settingsJSONString
         jsonError = nil
+        ensureGlobalDraft()
+        refreshFinalSettingsPreview()
     }
 
     private func syncFromJSON() {
-        guard let data = jsonText.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let obj = parsedJSONSettings(from: jsonText) else {
             return
         }
         profile.settings = obj
         profile.syncProxyFromSettings()
+        refreshFinalSettingsPreview()
     }
 
     /// Validate JSON, apply to profile, and reverse-sync metadata. Returns false on invalid JSON.
@@ -231,6 +359,258 @@ struct ProxyConfigEditorView: View {
             jsonError = error.localizedDescription
             return false
         }
+    }
+
+    private func parsedJSONSettings(from text: String) -> [String: Any]? {
+        guard let data = text.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+
+    private func ensureGlobalDraft() {
+        if globalConfigDraftSettings == nil {
+            globalConfigDraftSettings = viewModel.profileStore.globalConfig.settings
+        }
+    }
+
+    private func refreshFinalSettingsPreview() {
+        finalJSONText = finalSettingsPreviewText
+        finalJSONError = nil
+    }
+
+    private func applyFinalJSONEdit(_ text: String) {
+        finalJSONText = text
+        guard let finalSettings = parsedJSONSettings(from: text) else {
+            finalJSONError = L("Final settings must be valid JSON before it can update common/node config.",
+                               "最终配置必须是有效 JSON，才能回写通用配置/节点配置。")
+            return
+        }
+
+        finalJSONError = nil
+        ensureGlobalDraft()
+        let split = splitFinalSettingsEdit(
+            finalSettings,
+            global: currentGlobalSettings,
+            node: currentNodeSettings,
+            shouldMerge: shouldMergeCommonConfig
+        )
+
+        isApplyingFinalJSONEdit = true
+        globalConfigDraftSettings = split.global
+        jsonText = prettyJSONString(split.node)
+        profile.settings = split.node
+        profile.syncProxyFromSettings()
+        isApplyingFinalJSONEdit = false
+    }
+
+    private func prettyJSONString(_ object: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        ),
+        let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    private enum SettingsSource {
+        case common
+        case node
+        case override
+
+        var marker: String {
+            switch self {
+            case .common: return "C"
+            case .node: return "N"
+            case .override: return "O"
+            }
+        }
+    }
+
+    private struct SettingsSourceScope {
+        let depth: Int
+        let key: String
+        let source: SettingsSource
+    }
+
+    private func splitFinalSettingsEdit(
+        _ finalSettings: [String: Any],
+        global: [String: Any],
+        node: [String: Any],
+        shouldMerge: Bool
+    ) -> (global: [String: Any], node: [String: Any]) {
+        var nextGlobal = global
+        var nextNode = node
+
+        let oldFinal = shouldMerge
+            ? GlobalConfig.deepMerge(base: global, override: node)
+            : node
+        let oldLeaves = flattenedJSONLeaves(oldFinal)
+        let newLeaves = flattenedJSONLeaves(finalSettings)
+
+        for path in oldLeaves.keys where newLeaves[path] == nil {
+            switch sourceForPath(path, global: global, node: node, shouldMerge: shouldMerge) {
+            case .common:
+                removeJSONValue(at: path, from: &nextGlobal)
+            case .node, .override:
+                removeJSONValue(at: path, from: &nextNode)
+            }
+        }
+
+        for (path, value) in newLeaves {
+            let source = oldLeaves[path] == nil
+                ? (shouldMerge ? SettingsSource.common : SettingsSource.node)
+                : sourceForPath(path, global: global, node: node, shouldMerge: shouldMerge)
+            switch source {
+            case .common:
+                setJSONValue(value, at: path, in: &nextGlobal)
+            case .node, .override:
+                setJSONValue(value, at: path, in: &nextNode)
+            }
+        }
+
+        return (nextGlobal, nextNode)
+    }
+
+    private func lineMarkers(
+        for text: String,
+        global: [String: Any],
+        node: [String: Any],
+        shouldMerge: Bool
+    ) -> [Int: String] {
+        var markers: [Int: String] = [:]
+        var stack: [SettingsSourceScope] = []
+        let lines = text.components(separatedBy: .newlines)
+
+        for (index, line) in lines.enumerated() {
+            let indent = line.prefix { $0 == " " }.count
+            let depth = max(0, indent / 2)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("}") || trimmed.hasPrefix("]") {
+                if let source = stack.last?.source {
+                    markers[index + 1] = source.marker
+                }
+                while let last = stack.last, last.depth >= depth {
+                    stack.removeLast()
+                }
+                continue
+            }
+
+            while let last = stack.last, last.depth >= depth {
+                stack.removeLast()
+            }
+
+            guard let key = jsonKey(in: line) else {
+                if let source = stack.last?.source {
+                    markers[index + 1] = source.marker
+                }
+                continue
+            }
+
+            let path = stack.map(\.key) + [key]
+            let source = sourceForPath(path, global: global, node: node, shouldMerge: shouldMerge)
+            markers[index + 1] = source.marker
+
+            if lineContainsContainerStart(line) {
+                stack.append(SettingsSourceScope(depth: depth, key: key, source: source))
+            }
+        }
+
+        return markers
+    }
+
+    private func sourceForPath(
+        _ path: [String],
+        global: [String: Any],
+        node: [String: Any],
+        shouldMerge: Bool
+    ) -> SettingsSource {
+        guard shouldMerge else { return .node }
+        let hasGlobal = jsonValue(at: path, in: global) != nil
+        let hasNode = jsonValue(at: path, in: node) != nil
+        if hasGlobal && hasNode { return .override }
+        if hasNode { return .node }
+        return .common
+    }
+
+    private func flattenedJSONLeaves(_ object: [String: Any]) -> [[String]: Any] {
+        var result: [[String]: Any] = [:]
+        flattenJSONValue(object, path: [], into: &result)
+        return result
+    }
+
+    private func flattenJSONValue(_ value: Any, path: [String], into result: inout [[String]: Any]) {
+        if let dict = value as? [String: Any], !dict.isEmpty {
+            for (key, child) in dict {
+                flattenJSONValue(child, path: path + [key], into: &result)
+            }
+            return
+        }
+        result[path] = value
+    }
+
+    private func jsonValue(at path: [String], in object: [String: Any]) -> Any? {
+        guard !path.isEmpty else { return object }
+        var current: Any = object
+        for key in path {
+            guard let dict = current as? [String: Any],
+                  let next = dict[key] else {
+                return nil
+            }
+            current = next
+        }
+        return current
+    }
+
+    private func setJSONValue(_ value: Any, at path: [String], in object: inout [String: Any]) {
+        guard let first = path.first else { return }
+        if path.count == 1 {
+            object[first] = value
+            return
+        }
+        var child = object[first] as? [String: Any] ?? [:]
+        setJSONValue(value, at: Array(path.dropFirst()), in: &child)
+        object[first] = child
+    }
+
+    private func removeJSONValue(at path: [String], from object: inout [String: Any]) {
+        guard let first = path.first else { return }
+        if path.count == 1 {
+            object.removeValue(forKey: first)
+            return
+        }
+        guard var child = object[first] as? [String: Any] else { return }
+        removeJSONValue(at: Array(path.dropFirst()), from: &child)
+        if child.isEmpty {
+            object.removeValue(forKey: first)
+        } else {
+            object[first] = child
+        }
+    }
+
+    private func jsonKey(in line: String) -> String? {
+        let pattern = #"^\s*"((?:\\.|[^"\\])*)"\s*:"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)),
+              let range = Range(match.range(at: 1), in: line) else {
+            return nil
+        }
+        let raw = String(line[range])
+        if let data = "\"\(raw)\"".data(using: .utf8),
+           let decoded = try? JSONSerialization.jsonObject(with: data) as? String {
+            return decoded
+        }
+        return raw
+    }
+
+    private func lineContainsContainerStart(_ line: String) -> Bool {
+        guard let colon = line.firstIndex(of: ":") else { return false }
+        let tail = line[line.index(after: colon)...]
+        return tail.contains("{") || tail.contains("[")
     }
 
     // MARK: - Node Type Section
@@ -869,6 +1249,7 @@ struct ProxyConfigEditorView: View {
     private func saveProfile() {
         if selectedTab == .json {
             guard validateAndApplyJSON() else { return }
+            guard finalJSONError == nil else { return }
         } else {
             profile.syncEnvFromProxy()
         }
@@ -878,6 +1259,11 @@ struct ProxyConfigEditorView: View {
                 viewModel.addProfile(profile)
             } else {
                 await viewModel.updateProfile(profile)
+            }
+            if let globalConfigDraftSettings {
+                var draft = viewModel.profileStore.globalConfig
+                draft.settings = globalConfigDraftSettings
+                viewModel.profileStore.saveGlobalConfig(draft)
             }
             dismiss()
         }

--- a/AIUsage/Views/ProxyManagementView+Card.swift
+++ b/AIUsage/Views/ProxyManagementView+Card.swift
@@ -15,12 +15,14 @@ struct ConfigurationCardView: View, Equatable {
     let statsRequests: Int
     let statsSuccessRate: Double
     let lastRequestAt: Date?
+    let connectivityState: ProxyConnectivityTestState?
 
     var onDragChanged: (CGFloat) -> Void = { _ in }
     var onDragEnded: () -> Void = {}
     var onToggleActivation: () -> Void = {}
     var onToggleProxyOnly: () -> Void = {}
     var onCopyLaunchCommand: () -> Void = {}
+    var onTestConnectivity: () -> Void = {}
     var onEdit: () -> Void = {}
     var onDelete: () -> Void = {}
     var onDuplicate: () -> Void = {}
@@ -34,7 +36,8 @@ struct ConfigurationCardView: View, Equatable {
         lhs.isSelected == rhs.isSelected &&
         lhs.statsRequests == rhs.statsRequests &&
         lhs.statsSuccessRate == rhs.statsSuccessRate &&
-        lhs.lastRequestAt == rhs.lastRequestAt
+        lhs.lastRequestAt == rhs.lastRequestAt &&
+        lhs.connectivityState == rhs.connectivityState
     }
 
     private static let anthropicBrand = Color(red: 0.85, green: 0.47, blue: 0.34)
@@ -128,6 +131,23 @@ struct ConfigurationCardView: View, Equatable {
                     .buttonStyle(.plain)
                     .instantTooltip(L("Copy Launch Command", "复制启动命令"))
 
+                    Button(action: onTestConnectivity) {
+                        Group {
+                            if connectivityState?.isTesting == true {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "bolt.horizontal.circle.fill")
+                                    .font(.system(size: 18))
+                                    .foregroundStyle(connectivityTint)
+                            }
+                        }
+                        .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isBusy || connectivityState?.isTesting == true || config.nodeType.isCodex)
+                    .instantTooltip(connectivityTooltip)
+
                     Button(action: onEdit) {
                         Image(systemName: "pencil.circle.fill")
                             .font(.system(size: 18))
@@ -194,6 +214,24 @@ struct ConfigurationCardView: View, Equatable {
         return Color.primary.opacity(0.06)
     }
 
+    private var connectivityTint: Color {
+        switch connectivityState?.lastSucceeded {
+        case true: return .green
+        case false: return .red
+        case nil: return .orange
+        }
+    }
+
+    private var connectivityTooltip: String {
+        if connectivityState?.isTesting == true {
+            return L("Testing Connectivity", "正在测试连通性")
+        }
+        if let message = connectivityState?.message, !message.isEmpty {
+            return message
+        }
+        return L("Test Connectivity", "测试连通性")
+    }
+
     // MARK: - Context Menu
 
     @ViewBuilder
@@ -221,6 +259,11 @@ struct ConfigurationCardView: View, Equatable {
         Button { onCopyLaunchCommand() } label: {
             Label(L("Copy Launch Command", "复制启动命令"), systemImage: "doc.on.clipboard")
         }
+
+        Button { onTestConnectivity() } label: {
+            Label(L("Test Connectivity", "测试连通性"), systemImage: "bolt.horizontal.circle")
+        }
+        .disabled(isBusy || connectivityState?.isTesting == true || config.nodeType.isCodex)
 
         Divider()
 

--- a/AIUsage/Views/ProxyManagementView+List.swift
+++ b/AIUsage/Views/ProxyManagementView+List.swift
@@ -35,6 +35,7 @@ extension ProxyManagementView {
                             statsRequests: stats.totalRequests,
                             statsSuccessRate: stats.successRate,
                             lastRequestAt: stats.lastRequestAt,
+                            connectivityState: viewModel.connectivityTestStates[config.id],
                             onDragChanged: { t in
                                 if draggingConfigId != config.id {
                                     draggingConfigId = config.id
@@ -46,6 +47,7 @@ extension ProxyManagementView {
                             onToggleActivation: { Task { await viewModel.toggleActivation(config.id) } },
                             onToggleProxyOnly: { Task { await viewModel.toggleProxyOnly(config.id) } },
                             onCopyLaunchCommand: { viewModel.copyLaunchCommand(for: config.id) },
+                            onTestConnectivity: { Task { await viewModel.testConnectivity(config.id) } },
                             onEdit: {
                                 if let profile = viewModel.profileStore.profile(for: config.id) {
                                     editingProfile = profile

--- a/AIUsage/Views/ProxyManagementView+Toolbar.swift
+++ b/AIUsage/Views/ProxyManagementView+Toolbar.swift
@@ -22,6 +22,15 @@ extension ProxyManagementView {
                 ) {
                     showingSettingsEditor = true
                 }
+
+                actionBarButton(
+                    title: isSyncingCCSwitch ? L("Syncing", "同步中") : L("Sync cc-switch", "同步 cc-switch"),
+                    icon: "arrow.triangle.2.circlepath",
+                    tint: .secondary
+                ) {
+                    syncCCSwitch()
+                }
+                .disabled(isSyncingCCSwitch)
             }
 
             actionBarButton(
@@ -85,6 +94,18 @@ extension ProxyManagementView {
             )
         }
         .buttonStyle(.plain)
+    }
+
+    func syncCCSwitch() {
+        guard !isSyncingCCSwitch else { return }
+        isSyncingCCSwitch = true
+        Task { @MainActor in
+            let result = viewModel.profileStore.importCCSwitchClaudeProfiles()
+            importResult = result
+            showImportResult = true
+            viewModel.loadConfigurations()
+            isSyncingCCSwitch = false
+        }
     }
 
     // MARK: - Summary Strip

--- a/AIUsage/Views/ProxyManagementView.swift
+++ b/AIUsage/Views/ProxyManagementView.swift
@@ -27,6 +27,7 @@ struct ProxyManagementView: View {
     @State var showImportResult = false
     @State var exportSelectedIds: Set<String> = []
     @State var showingSettingsEditor = false
+    @State var isSyncingCCSwitch = false
 
     // MARK: - Family Filtering
 
@@ -186,6 +187,23 @@ struct ProxyManagementView: View {
             Text(viewModel.operationErrorMessage ?? "")
         }
         .alert(
+            L("Connectivity Test", "连通性测试"),
+            isPresented: Binding(
+                get: { viewModel.connectivityTestMessage != nil },
+                set: { newValue in
+                    if !newValue {
+                        viewModel.connectivityTestMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                viewModel.connectivityTestMessage = nil
+            }
+        } message: {
+            Text(viewModel.connectivityTestMessage ?? "")
+        }
+        .alert(
             L("Delete Node?", "确认删除节点？"),
             isPresented: Binding(
                 get: { pendingDeletionConfig != nil },
@@ -245,6 +263,31 @@ struct ProxyManagementView: View {
                 .clipShape(Capsule())
             }
             .buttonStyle(.plain)
+
+            if !family.isCodex {
+                Button(action: { syncCCSwitch() }) {
+                    HStack {
+                        if isSyncingCCSwitch {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                        }
+                        Text(isSyncingCCSwitch ? L("Syncing cc-switch", "正在同步 cc-switch") : L("Sync cc-switch", "同步 cc-switch"))
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 8)
+                    .background(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.05))
+                    .foregroundStyle(.primary)
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(isSyncingCCSwitch)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -299,6 +342,9 @@ struct ProxyManagementView: View {
         var notes = ""
         if result.importedGlobalConfig {
             notes += "\n" + L("Claude common config imported.", "Claude 通用配置已导入。")
+        }
+        if result.skippedGlobalConfig {
+            notes += "\n" + L("Claude common config already exists, skipped.", "已有 Claude 通用配置，已跳过。")
         }
         if result.importedCodexGlobalConfig {
             notes += "\n" + L("Codex common config imported.", "Codex 通用配置已导入。")


### PR DESCRIPTION
## Summary
- Add one-click cc-switch Claude profile import, including common config handling.
- Add per-node common config merge strategies and a layered final JSON editor for Claude settings.
- Add Claude node connectivity testing and improve JSON editor UX with search, folding, line numbers, and source highlighting.

## Test Plan
- `rtk xcodebuild -project AIUsage.xcodeproj -scheme AIUsage -configuration Debug -destination 'platform=macOS' -derivedDataPath .derivedData build`\n- `rtk swift test --package-path QuotaBackend`\n- `rtk git diff --check`