### PR TITLE
feat(opencode): 用量数据自存储，删除会话后统计不丢

### DIFF
--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
@@ -37,15 +37,6 @@ extension OpenCodeCostProvider {
 
     // MARK: Aggregation
 
-    /// rows → 按日聚合桶。
-    func buildDays(rows: [CodexRow]) -> [String: CodexAggregateBucket] {
-        var days: [String: CodexAggregateBucket] = [:]
-        for row in rows {
-            days[row.dayKey, default: .empty].record(row: row)
-        }
-        return days
-    }
-
     func aggregateDays(
         _ bucketsByDay: [String: CodexAggregateBucket],
         matching: (String) -> Bool

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
@@ -13,6 +13,7 @@ extension OpenCodeCostProvider {
 
     /// message 表的一行原始数据（data 为 OpenCode 的消息 JSON）。
     struct MessageRow: Sendable {
+        let messageId: String
         let sessionId: String
         let timeCreatedMillis: Int64
         let data: Data
@@ -28,7 +29,7 @@ extension OpenCodeCostProvider {
         }
         defer { sqlite3_close(db) }
 
-        var sql = "SELECT session_id, time_created, data FROM message"
+        var sql = "SELECT id, session_id, time_created, data FROM message"
         if sinceMillis != nil {
             sql += " WHERE time_created >= ?"
         }
@@ -53,13 +54,15 @@ extension OpenCodeCostProvider {
                 throw ProviderError("db_step_failed", SensitiveDataRedactor.redactPaths(in: message))
             }
 
-            guard let sessionCString = sqlite3_column_text(statement, 0),
-                  let dataCString = sqlite3_column_text(statement, 2) else {
+            guard let idCString = sqlite3_column_text(statement, 0),
+                  let sessionCString = sqlite3_column_text(statement, 1),
+                  let dataCString = sqlite3_column_text(statement, 3) else {
                 continue
             }
             rows.append(MessageRow(
+                messageId: String(cString: idCString),
                 sessionId: String(cString: sessionCString),
-                timeCreatedMillis: sqlite3_column_int64(statement, 1),
+                timeCreatedMillis: sqlite3_column_int64(statement, 2),
                 data: Data(String(cString: dataCString).utf8)
             ))
         }

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
@@ -41,9 +41,10 @@ extension OpenCodeCostProvider {
     /// 这里排除以免在 OpenCode 用量/费用/热力图里被重复计数。per-node 受管键恒为 `aiusage-<slug>`，不受影响。
     static let globalProxyProviderID = "aiusage"
 
-    /// 解析一行 message；非 assistant、零用量或无法解码的行返回 nil。
+    /// 解析一行 message 为账本明细条目；非 assistant、零用量或无法解码的行返回 nil。
+    /// 保留 messageId/sessionId/timeCreatedMillis 用于增量账本去重与明细追溯（issue #67）。
     /// decoder 由调用方每次 fetch 创建一只并复用（避免逐行新建，也避免跨任务共享）。
-    func parseMessageRow(_ row: MessageRow, decoder: JSONDecoder) -> CodexRow? {
+    func parseLedgerEntry(_ row: MessageRow, decoder: JSONDecoder) -> OpenCodeLedgerEntry? {
         guard let message = try? decoder.decode(MessageData.self, from: row.data),
               message.role == "assistant" else {
             return nil
@@ -63,13 +64,16 @@ extension OpenCodeCostProvider {
         guard totalTokens > 0 || cost > 0 else { return nil }
 
         let createdAt = Date(timeIntervalSince1970: Double(row.timeCreatedMillis) / 1000)
-        return CodexRow(
+        return OpenCodeLedgerEntry(
+            messageId: row.messageId,
+            sessionId: row.sessionId,
+            timeCreatedMillis: row.timeCreatedMillis,
             dayKey: dayKey(createdAt),
             model: modelLabel(providerID: message.providerID, modelID: message.modelID),
             inputTokens: inputTokens,
+            outputTokens: outputTokens,
             cacheReadTokens: cacheReadTokens,
             cacheCreateTokens: cacheCreateTokens,
-            outputTokens: outputTokens,
             totalTokens: totalTokens,
             estimatedCostUsd: cost
         )

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -21,6 +21,8 @@ public struct OpenCodeCostProvider: ProviderFetcher {
 
     /// 永久每日归档（每个 home 一张，按 homeDirectory 区分以隔离测试 / 多配置）。
     static let archive = OpenCodeUsageArchiveStore()
+    /// 独立明细账本（message 级，按 message.id 去重增量），issue #67 的持久真相源。
+    static let ledger = OpenCodeLedgerStore()
     static let defaultScanDays = 30
 
     public init(
@@ -37,31 +39,35 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         let now = Date()
         let todayKey = dayKey(now)
 
-        // 首次（归档从未完成全量）触发全量扫描以冻结所有历史日；之后只扫窗口。
-        let shouldImportFullHistory = await Self.archive.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
+        // 首次（账本从未完成全量）触发全量扫描以回填账本全部明细；之后只扫窗口。
+        let shouldImportFullHistory = await Self.ledger.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
         let sinceMillis: Int64? = shouldImportFullHistory ? nil : scanWindowStartMillis(now: now)
 
-        // 1) 读库（OpenCode 未安装/版本过旧时跳过：冻结归档可能仍有历史数据）。
+        // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/版本过旧时跳过，账本仍有历史）。
         let dataDirectory = resolveDataDirectory()
-        var sessionIds = Set<String>()
-        var computed: [String: CodexAggregateBucket] = [:]
         if let dataDirectory {
             let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
             defer { cleanupDatabaseSnapshot(snapshotPath) }
             let messageRows = try fetchMessageRows(databasePath: snapshotPath, sinceMillis: sinceMillis)
             let decoder = JSONDecoder()
-            var rows: [CodexRow] = []
-            rows.reserveCapacity(messageRows.count)
+            var entries: [OpenCodeLedgerEntry] = []
+            entries.reserveCapacity(messageRows.count)
             for messageRow in messageRows {
-                guard let row = parseMessageRow(messageRow, decoder: decoder) else { continue }
-                rows.append(row)
-                sessionIds.insert(messageRow.sessionId)
+                guard let entry = parseLedgerEntry(messageRow, decoder: decoder) else { continue }
+                entries.append(entry)
             }
-            computed = buildDays(rows: rows)
+            await Self.ledger.merge(
+                homeDirectory: homeDirectory,
+                newEntries: entries,
+                completedFullHistory: shouldImportFullHistory
+            )
         }
         relieveMallocPressure()
 
-        // 2) 冻结归档：昨日前首写冻结、今天覆盖重算；删除本地库后历史不丢。
+        // 2) 账本聚合 → 冻结归档：昨日前首写冻结、今天从账本累积覆盖（删除会话后账本不删，统计不丢）。
+        let ledgerEntries = await Self.ledger.allEntries(homeDirectory: homeDirectory)
+        let sessionIds = Set(ledgerEntries.map { $0.sessionId })
+        let computed = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
         let dbDays = await Self.archive.freeze(
             homeDirectory: homeDirectory,
             computed: computed,

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+import os.log
+
+private let openCodeLedgerLog = Logger(subsystem: "com.aiusage.quotabackend", category: "OpenCodeLedger")
+
+// MARK: - OpenCode Ledger Store
+// OpenCode 本地会话用量的「独立明细账本」（issue #67）。
+// 与 usage-archive 的「日聚合冻结」不同，本账本按 message 级明细持久化，
+// 以 opencode.db message.id 为主键做 upsert，从而在 opencode 侧删除会话 / 清空历史后，
+// 已记录的 token/cost 明细仍可追溯、不丢失。
+//
+// 语义：
+// - upsert：本次扫描读到的 message（按 id）覆盖旧值——处理 opencode 流式过程中 token 数的渐进更新。
+// - 保留：本次扫描读不到的 message（opencode 侧已删除，或超出扫描窗口）不从账本删除——删除不丢账。
+//
+// 持久化（永久、放 ~/.config/aiusage 避免被系统清理）:
+//   <home>/.config/aiusage/usage-archive/opencode-ledger-v<version>.json
+// 与 usage-archive 同目录但独立文件，避免污染 Codex/Claude 共享的 CodexUsageArchive 结构。
+
+/// 一条 assistant 消息的完整用量明细（满足 issue #67「明细可追溯」：时间/模型/各类型 token/cost）。
+struct OpenCodeLedgerEntry: Codable, Sendable, Equatable {
+    /// opencode.db message.id（text 主键，如 `msg_xxx`），账本去重键。
+    let messageId: String
+    let sessionId: String
+    /// 消息创建时间（epoch 毫秒，来自 message.time_created）。
+    let timeCreatedMillis: Int64
+    /// 归属日（yyyy-MM-dd，解析时按 provider 时区固定，避免时区漂移）。
+    let dayKey: String
+    /// 模型名口径 `providerID/modelID`。
+    let model: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheCreateTokens: Int
+    let totalTokens: Int
+    /// models.dev 定价的冻结成本（订阅渠道恒 0，非「未定价」）。
+    let estimatedCostUsd: Double
+
+    func asCodexRow() -> CodexRow {
+        CodexRow(
+            dayKey: dayKey,
+            model: model,
+            inputTokens: inputTokens,
+            cacheReadTokens: cacheReadTokens,
+            cacheCreateTokens: cacheCreateTokens,
+            outputTokens: outputTokens,
+            totalTokens: totalTokens,
+            estimatedCostUsd: estimatedCostUsd
+        )
+    }
+}
+
+/// 账本文件结构（version 1）。
+struct OpenCodeLedger: Codable, Sendable {
+    let version: Int
+    var updatedAt: String
+    var entries: [String: OpenCodeLedgerEntry]
+    var fullHistoryImportedAt: String?
+}
+
+actor OpenCodeLedgerStore {
+    static let artifactVersion = 1
+
+    private var ledgers: [String: OpenCodeLedger] = [:]
+    private var loaded: Set<String> = []
+
+    /// 首次返回 true（触发一次全量扫描以回填账本全部明细），完成后恒 false。
+    func consumeFullHistoryImportRequest(homeDirectory: String) -> Bool {
+        load(homeDirectory).fullHistoryImportedAt == nil
+    }
+
+    /// 按 messageId upsert 合并本次读到的明细；账本中读不到的条目保留（删除不丢）。
+    /// 返回合并后的全部明细，供调用方聚合与 sessionCount 统计。
+    @discardableResult
+    func merge(
+        homeDirectory: String,
+        newEntries: [OpenCodeLedgerEntry],
+        completedFullHistory: Bool
+    ) -> [OpenCodeLedgerEntry] {
+        var ledger = load(homeDirectory)
+        var changed = false
+
+        for entry in newEntries {
+            if ledger.entries[entry.messageId] != entry {
+                ledger.entries[entry.messageId] = entry
+                changed = true
+            }
+        }
+
+        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
+            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+            changed = true
+        }
+
+        if changed {
+            ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+            ledgers[homeDirectory] = ledger
+            save(homeDirectory, ledger)
+        } else {
+            ledgers[homeDirectory] = ledger
+        }
+        return Array(ledger.entries.values)
+    }
+
+    /// 读取账本全部明细（不触发写）。
+    func allEntries(homeDirectory: String) -> [OpenCodeLedgerEntry] {
+        Array(load(homeDirectory).entries.values)
+    }
+
+    /// 从明细聚合日桶（复用 CodexAggregateBucket.record）。
+    static func aggregateDays(_ entries: [OpenCodeLedgerEntry]) -> [String: CodexAggregateBucket] {
+        var days: [String: CodexAggregateBucket] = [:]
+        for entry in entries {
+            days[entry.dayKey, default: .empty].record(row: entry.asCodexRow())
+        }
+        return days
+    }
+
+    // MARK: Disk
+
+    private func load(_ homeDirectory: String) -> OpenCodeLedger {
+        if let ledger = ledgers[homeDirectory], loaded.contains(homeDirectory) { return ledger }
+        loaded.insert(homeDirectory)
+
+        if let data = try? Data(contentsOf: Self.fileURL(homeDirectory: homeDirectory)),
+           let decoded = try? JSONDecoder().decode(OpenCodeLedger.self, from: data),
+           decoded.version == Self.artifactVersion {
+            ledgers[homeDirectory] = decoded
+            return decoded
+        }
+
+        let fresh = OpenCodeLedger(version: Self.artifactVersion, updatedAt: "", entries: [:])
+        ledgers[homeDirectory] = fresh
+        return fresh
+    }
+
+    private func save(_ homeDirectory: String, _ ledger: OpenCodeLedger) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(ledger)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            openCodeLedgerLog.warning("Failed to save OpenCode ledger: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    static func fileURL(homeDirectory: String) -> URL {
+        let dir = (homeDirectory as NSString).appendingPathComponent(".config/aiusage/usage-archive")
+        return URL(fileURLWithPath: dir, isDirectory: true)
+            .appendingPathComponent("opencode-ledger-v\(artifactVersion).json")
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import Foundation
+@testable import QuotaBackend
+
+final class OpenCodeLedgerStoreTests: XCTestCase {
+    func testMergeAccumulatesNewEntriesAcrossBatches() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        var days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 300)
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 2)
+
+        // 第二批：新 msg_3 + 更新 msg_2（同 id 覆盖）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+            entry(id: "msg_2", tokens: 250),
+        ], completedFullHistory: false)
+
+        days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 650)  // 100 + 250 + 300
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 3)
+    }
+
+    func testMergeRetainsEntriesNotInLaterBatch() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        // 模拟删除会话：第二批只含 msg_3（msg_1 已从 opencode.db 消失）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+        ], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 600)  // 100 + 200 + 300（msg_1 不丢）
+    }
+
+    func testMergeUpdatesExistingEntryWithoutDoubleCounting() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 100)], completedFullHistory: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 250)], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 250)  // 更新覆盖，不重复计数
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 1)
+    }
+
+    func testAggregateDaysGroupsByDayKey() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", tokens: 100),
+            entry(id: "msg_2", day: "2026-01-02", tokens: 200),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days.count, 2)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 100)
+        XCTAssertEqual(days["2026-01-02"]?.totalTokens, 200)
+    }
+
+    func testAggregateDaysSumCostAndTokensByModel() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", model: "anthropic/sonnet", tokens: 100, cost: 0.01),
+            entry(id: "msg_2", day: "2026-01-01", model: "anthropic/sonnet", tokens: 200, cost: 0.02),
+            entry(id: "msg_3", day: "2026-01-01", model: "openai/gpt-5", tokens: 300, cost: 0.03),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        let day = days["2026-01-01"]
+        XCTAssertEqual(day?.totalTokens, 600)
+        XCTAssertEqual(day?.estimatedCostUsd ?? 0, 0.06, accuracy: 0.0001)
+        XCTAssertEqual(day?.models.count, 2)
+        XCTAssertEqual(day?.models["anthropic/sonnet"]?.totalTokens, 300)
+        XCTAssertEqual(day?.models["openai/gpt-5"]?.totalTokens, 300)
+    }
+
+    func testFullHistoryImportFlagPersists() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        var shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertTrue(shouldImport)
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], completedFullHistory: true)
+
+        shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    func testFullHistoryImportFlagSetOnEmptyMerge() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        // 全量导入但 db 为空（无 assistant 消息）→ 仍标记已完成，避免每次重复全量扫描。
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], completedFullHistory: true)
+
+        let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    // MARK: Helpers
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-ledger-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func aggregatedDays(_ store: OpenCodeLedgerStore, home: String) async -> [String: CodexAggregateBucket] {
+        let entries = await store.allEntries(homeDirectory: home)
+        return OpenCodeLedgerStore.aggregateDays(entries)
+    }
+
+    private func entry(
+        id: String,
+        day: String = "2026-01-01",
+        model: String = "anthropic/claude-sonnet",
+        tokens: Int = 100,
+        cost: Double = 0.01
+    ) -> OpenCodeLedgerEntry {
+        OpenCodeLedgerEntry(
+            messageId: id,
+            sessionId: "sess-1",
+            timeCreatedMillis: 1_700_000_000_000,
+            dayKey: day,
+            model: model,
+            inputTokens: tokens,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreateTokens: 0,
+            totalTokens: tokens,
+            estimatedCostUsd: cost
+        )
+    }
+}


### PR DESCRIPTION
## 概述

修复 #67：OpenCode 用量数据自存储，删除会话后统计不再丢失。

## 问题

当前 OpenCode 用量统计直接读 `opencode.db` 会话消息，"今天"的统计每次刷新全量重算，完全绑定 opencode 会话。删除/清空 opencode 会话或切换 auth.json 后，统计丢失（详见 #32、#67）。

## 方案

新增 OpenCode 用量明细账本（`opencode-ledger-v1.json`），作为独立持久真相源：

- 每次刷新把 opencode.db 读取到的明细（时间、模型、各类型 token、cost、会话归属）按 `messageId` 增量 upsert 到账本
- 账本中读不到的条目保留（删除会话后已记录数据不丢）
- "今天"的统计也从账本聚合，而非 opencode.db 全量重算

## 改动

- 新增 `OpenCodeLedgerStore.swift`：明细账本 actor（镜像 `OpenCodeUsageArchiveStore` 风格）
- `OpenCodeCostProvider+Database.swift`：读取 `message.id` 作为稳定去重键
- `OpenCodeCostProvider+Parsing.swift`：`parseMessageRow` → `parseLedgerEntry`（输出含会话归属与时间戳）
- `OpenCodeCostProvider.swift`：`fetchUsage` 改账本流，删除 `buildDays`（被账本聚合取代）
- 新增 `OpenCodeLedgerStoreTests.swift`：覆盖累加、删除不丢、更新、按日/按模型聚合等 7 个用例

## 验证

- 本机 `swift build` 通过（LSP 0 诊断）
- CI `swift test`（macos-26 / Xcode 26）通过

## 兼容性

- 与现有冻结归档兼容：`freeze` 归档逻辑未改，仅 `computed` 来源由 db 直接聚合改为账本聚合
- 不影响 Claude/Codex：三者仅共享通用数据模型（`CodexRow`/`CodexAggregateBucket`），无状态共享