### PR TITLE
feat(opencode): 用量数据自存储，删除会话后统计不丢

### DIFF
--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -13,6 +13,8 @@ public actor CallAnalyticsEngine {
     let environment: [String: String]
     /// 永久每日冻结归档（issue #32）：删 session 后历史调用统计不丢。仅本 actor 访问，串行安全。
     private let archive: CallAnalyticsArchiveStore
+    /// OpenCode 明细账本（issue #67 调用分析部分）：按 part.id upsert、读不到的不删，删 session 后调用明细不丢。
+    private let opencodeLedger: OpenCodeCallLedgerStore
 
     public init(
         homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
@@ -23,6 +25,7 @@ public actor CallAnalyticsEngine {
         self.timeZone = timeZone
         self.environment = environment
         self.archive = CallAnalyticsArchiveStore(homeDirectory: homeDirectory)
+        self.opencodeLedger = OpenCodeCallLedgerStore(homeDirectory: homeDirectory)
     }
 
     /// 计算调用分析快照。
@@ -52,16 +55,21 @@ public actor CallAnalyticsEngine {
             .collect(cutoff: scanCutoff)
         let codex = CodexCallEventSource(homeDirectory: homeDirectory, timeZone: timeZone, environment: environment)
             .collect(cutoff: scanCutoff)
-        let opencode = OpenCodeCallEventSource(
+        let opencodeRaw = OpenCodeCallEventSource(
             homeDirectory: homeDirectory, timeZone: timeZone, environment: environment,
             knownMCPServers: openCodeServers
         ).collect(cutoff: scanCutoff)
+
+        // OpenCode 明细账本：issue #67 调用分析部分。按 part.id upsert、读不到的不删，
+        // 使删除 opencode 会话后已记录的调用明细不丢；再从账本聚合回计数条目。
+        let opencodeLedgerEntries = opencodeLedger.merge(newEntries: opencodeRaw.entries, completedFullHistory: needsFullImport)
+        let opencodeEntries = OpenCodeCallLedgerStore.aggregate(opencodeLedgerEntries)
 
         // 实时结果按日分桶（entries 自带 dayKey；Claude 的 agentInvocations 已按天归属）。
         var computed: [String: CallAnalyticsDayBucket] = [:]
         for entry in claude.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
         for entry in codex.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
-        for entry in opencode.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
+        for entry in opencodeEntries { computed[entry.dayKey, default: .empty].entries.append(entry) }
         for (day, invs) in claude.agentInvocationsByDay {
             computed[day, default: .empty].agentInvocations.append(contentsOf: invs)
         }
@@ -88,7 +96,7 @@ public actor CallAnalyticsEngine {
 
         // 各源对外展示的「调用次数」以归档展示条目为准，避免页脚 M 次调用与上方 KPI 对不上；
         // available / filesScanned / errorCode 沿用本次实时扫描状态。
-        let rawStatuses = [claude.status, codex.status, opencode.status]
+        let rawStatuses = [claude.status, codex.status, opencodeRaw.status]
         let statuses = rawStatuses.map { status -> CallSourceStatus in
             let count = entries.filter { $0.source == status.source }.reduce(0) { $0 + $1.count }
             return CallSourceStatus(

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallEventSource.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallEventSource.swift
@@ -25,7 +25,7 @@ struct OpenCodeCallEventSource {
         "list", "webfetch", "patch", "task", "question", "todowrite", "todoread", "invalid"
     ]
 
-    func collect(cutoff: Date?) -> (entries: [CallAnalyticsEntry], status: CallSourceStatus) {
+    func collect(cutoff: Date?) -> (entries: [OpenCodeCallLedgerEntry], status: CallSourceStatus) {
         let clock = CallAnalyticsClock(timeZone: timeZone)
         guard let dataDirectory = resolveDataDirectory() else {
             return ([], CallSourceStatus(source: .opencode, available: false, eventCount: 0, filesScanned: 0, errorCode: nil))
@@ -41,10 +41,12 @@ struct OpenCodeCallEventSource {
         defer { cleanupDatabaseSnapshot(snapshotPath) }
 
         let sinceMillis: Int64? = cutoff.map { Int64($0.timeIntervalSince1970 * 1000) }
-        var accumulator = CallEventAccumulator()
+        var entries: [OpenCodeCallLedgerEntry] = []
         do {
-            try forEachToolPart(databasePath: snapshotPath, sinceMillis: sinceMillis) { millis, data in
-                parsePart(data, millis: millis, clock: clock, into: &accumulator)
+            try forEachToolPart(databasePath: snapshotPath, sinceMillis: sinceMillis) { partId, millis, data in
+                if let entry = parsePart(partId: partId, data, millis: millis, clock: clock) {
+                    entries.append(entry)
+                }
             }
         } catch {
             let code = (error as? ProviderError)?.code ?? "db_query_failed"
@@ -54,38 +56,38 @@ struct OpenCodeCallEventSource {
         let status = CallSourceStatus(
             source: .opencode,
             available: true,
-            eventCount: accumulator.eventCount,
+            eventCount: entries.count,
             filesScanned: 1,
             errorCode: nil
         )
-        return (accumulator.entries(), status)
+        return (entries, status)
     }
 
     // MARK: - Parsing
 
     private func parsePart(
+        partId: String,
         _ data: Data,
         millis: Int64,
-        clock: CallAnalyticsClock,
-        into accumulator: inout CallEventAccumulator
-    ) {
+        clock: CallAnalyticsClock
+    ) -> OpenCodeCallLedgerEntry? {
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               (object["type"] as? String) == "tool",
               let tool = (object["tool"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
               !tool.isEmpty else {
-            return
+            return nil
         }
         let dayKey = clock.dayKey(fromMillis: millis)
         let state = object["state"] as? [String: Any]
-        classify(tool: tool, state: state, dayKey: dayKey, into: &accumulator)
+        return classify(partId: partId, tool: tool, state: state, dayKey: dayKey)
     }
 
     private func classify(
+        partId: String,
         tool: String,
         state: [String: Any]?,
-        dayKey: String,
-        into accumulator: inout CallEventAccumulator
-    ) {
+        dayKey: String
+    ) -> OpenCodeCallLedgerEntry {
         let lower = tool.lowercased()
         // OpenCode 每条 tool part 自带 status 与 time，故成功率/耗时对所有类别（MCP/技能/工具）通用。
         let success = Self.outcome(from: state)
@@ -95,30 +97,25 @@ struct OpenCodeCallEventSource {
             let input = state?["input"] as? [String: Any]
             let raw = (input?["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let skillName = raw.isEmpty ? "(unknown)" : raw
-            accumulator.add(source: .opencode, kind: .skill, name: skillName, server: nil, dayKey: dayKey,
-                            success: success, durationMs: durationMs)
-            return
+            return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: .skill, name: skillName, server: nil, success: success, durationMs: durationMs)
         }
 
         if Self.builtinTools.contains(lower) {
             let kind: CallKind = lower == "webfetch" ? .webSearch : .builtin
-            accumulator.add(source: .opencode, kind: kind, name: tool, server: nil, dayKey: dayKey,
-                            success: success, durationMs: durationMs)
-            return
+            return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: kind, name: tool, server: nil, success: success, durationMs: durationMs)
         }
 
         // 优先用已装 server 名做最长前缀匹配（server 名本身含 `_`/`-` 时切分才准），匹配不到再回退。
         if let match = matchKnownServer(tool: tool) {
-            accumulator.add(
-                source: .opencode,
+            return OpenCodeCallLedgerEntry(
+                partId: partId,
+                dayKey: dayKey,
                 kind: .mcp,
                 name: CallAnalyticsNaming.mcpDisplayName(server: match.server, tool: match.tool),
                 server: match.server,
-                dayKey: dayKey,
                 success: success,
                 durationMs: durationMs
             )
-            return
         }
 
         // 回退启发式：OpenCode 把 MCP 工具命名为 `<server>_<tool>`；非内置且含下划线者归为 MCP。
@@ -126,21 +123,19 @@ struct OpenCodeCallEventSource {
             let server = String(tool[tool.startIndex..<sep])
             let toolName = String(tool[tool.index(after: sep)...])
             if !server.isEmpty, !toolName.isEmpty {
-                accumulator.add(
-                    source: .opencode,
+                return OpenCodeCallLedgerEntry(
+                    partId: partId,
+                    dayKey: dayKey,
                     kind: .mcp,
                     name: CallAnalyticsNaming.mcpDisplayName(server: server, tool: toolName),
                     server: server,
-                    dayKey: dayKey,
                     success: success,
                     durationMs: durationMs
                 )
-                return
             }
         }
 
-        accumulator.add(source: .opencode, kind: .other, name: tool, server: nil, dayKey: dayKey,
-                        success: success, durationMs: durationMs)
+        return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: .other, name: tool, server: nil, success: success, durationMs: durationMs)
     }
 
     /// 从 part.state 判定成功/失败：completed→成功，error→失败，其余（pending/running 等）→nil（不计入分母）。
@@ -217,7 +212,7 @@ struct OpenCodeCallEventSource {
     private func forEachToolPart(
         databasePath: String,
         sinceMillis: Int64?,
-        onRow: (Int64, Data) -> Void
+        onRow: (String, Int64, Data) -> Void
     ) throws {
         var db: OpaquePointer?
         guard sqlite3_open_v2(databasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
@@ -227,7 +222,7 @@ struct OpenCodeCallEventSource {
         }
         defer { sqlite3_close(db) }
 
-        var sql = "SELECT time_created, data FROM part WHERE data LIKE '%\"type\":\"tool\"%'"
+        var sql = "SELECT id, time_created, data FROM part WHERE data LIKE '%\"type\":\"tool\"%'"
         if sinceMillis != nil {
             sql += " AND time_created >= ?"
         }
@@ -250,9 +245,11 @@ struct OpenCodeCallEventSource {
                 let message = String(cString: sqlite3_errmsg(db))
                 throw ProviderError("db_step_failed", SensitiveDataRedactor.redactPaths(in: message))
             }
-            guard let dataCString = sqlite3_column_text(statement, 1) else { continue }
-            let millis = sqlite3_column_int64(statement, 0)
-            onRow(millis, Data(String(cString: dataCString).utf8))
+            guard let idCString = sqlite3_column_text(statement, 0) else { continue }
+            let partId = String(cString: idCString)
+            let millis = sqlite3_column_int64(statement, 1)
+            guard let dataCString = sqlite3_column_text(statement, 2) else { continue }
+            onRow(partId, millis, Data(String(cString: dataCString).utf8))
         }
         openCodeCallLog.debug("OpenCode call-analytics scanned part rows")
     }

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
@@ -1,0 +1,191 @@
+import Foundation
+import os.log
+
+private let openCodeCallLedgerLog = Logger(subsystem: "com.aiusage.quotabackend", category: "OpenCodeCallLedger")
+
+// MARK: - OpenCode Call Ledger Store
+// 「调用分析」OpenCode 源的明细账本（issue #67 的调用分析部分）。
+// 解决「删除 opencode 会话后，工具/MCP/Skill 调用次数统计丢失」。
+//
+// 数据源：opencode.db 的 `part` 表。message 删除会对 part 做级联删除（onDelete: cascade），
+// 因此删 session 后 part 行消失，实时重扫拿不到 → 今天的调用次数减少。
+// 本账本把每条 tool part（按 `part.id`，即 `prt_xxx`）持久化，扫描时按 id upsert、
+// 读不到的不删，从而在 opencode 侧删会话后仍保留已记录的调用明细。
+//
+// 语义：
+// - 本次扫描读到的 part 按 `id` upsert（覆盖旧值，处理 part 状态从 running→completed 的更新）；
+// - 账本里本次读不到的 part 不删（处理「删除会话」不丢账）；
+// - 首次启动做一次「全量历史导入」（completedFullHistory 标记），之后只扫请求窗口。
+//
+// 聚合：`aggregate` 把明细条目还原为「日 × 类别 × 名称(× server)」的 CallAnalyticsEntry，
+// 与实时 CallEventAccumulator 口径一致（count / outcomeKnownCount / successCount /
+// durationSampleCount / durationMsTotal）。
+//
+// 持久化（永久，放 ~/.config/aiusage 避免被系统磁盘清理）:
+//   <home>/.config/aiusage/usage-archive/opencode-call-ledger-v<version>.json
+//
+// 线程：本类仅由 CallAnalyticsEngine（actor）持有并访问，访问被引擎 actor 串行化，
+// 故与 CallAnalyticsArchiveStore 一样无需自身加锁。
+
+/// 一条 OpenCode 工具调用明细（对应 part 表的一行 tool part）。
+struct OpenCodeCallLedgerEntry: Codable, Sendable, Equatable {
+    /// part 表主键（`prt_xxx`），稳定唯一去重键。
+    let partId: String
+    /// yyyy-MM-dd（本地时区），由 part.time_created 派生。
+    let dayKey: String
+    /// 调用类别（mcp / skill / builtin / webSearch / other）。
+    let kind: CallKind
+    /// 展示名：MCP=`server/tool`，Skill=技能名，其它=工具名。
+    let name: String
+    /// 仅 MCP 有值。
+    let server: String?
+    /// 成功/失败（nil = 无结果信号，如 pending/running）。
+    let success: Bool?
+    /// 耗时（毫秒），缺失或非法为 nil。
+    let durationMs: Double?
+}
+
+/// 账本文件结构。
+struct OpenCodeCallLedger: Codable, Sendable {
+    let version: Int
+    var updatedAt: String
+    var entries: [String: OpenCodeCallLedgerEntry]
+    var fullHistoryImportedAt: String?
+}
+
+final class OpenCodeCallLedgerStore {
+    static let artifactVersion = 1
+
+    private let homeDirectory: String
+    private var cached: OpenCodeCallLedger?
+
+    init(homeDirectory: String) {
+        self.homeDirectory = homeDirectory
+    }
+
+    /// 是否已完成全量历史导入。false → 引擎应先扫全历史以冻结所有过去日。
+    var fullHistoryImported: Bool {
+        load().fullHistoryImportedAt != nil
+    }
+
+    /// 合并本次扫描到的明细：按 partId upsert，账本里读不到的不删。
+    /// `completedFullHistory` 为 true 时无条件标记全量导入完成（即使本次为空，也避免重复全量扫描）。
+    /// 返回合并后的全部明细（含被删除会话的历史）。
+    @discardableResult
+    func merge(newEntries: [OpenCodeCallLedgerEntry], completedFullHistory: Bool) -> [OpenCodeCallLedgerEntry] {
+        var ledger = load()
+        var changed = false
+
+        for entry in newEntries {
+            if ledger.entries[entry.partId] != entry {
+                ledger.entries[entry.partId] = entry
+                changed = true
+            }
+        }
+
+        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
+            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+            changed = true
+        }
+
+        if changed {
+            ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+            cached = ledger
+            save(ledger)
+        } else {
+            cached = ledger
+        }
+        return Array(ledger.entries.values)
+    }
+
+    /// 账本全部明细（含被删除会话的历史）。
+    func allEntries() -> [OpenCodeCallLedgerEntry] {
+        Array(load().entries.values)
+    }
+
+    /// 把明细条目聚合为「日 × 类别 × 名称(× server)」的计数条目，口径与实时 CallEventAccumulator 一致。
+    static func aggregate(_ entries: [OpenCodeCallLedgerEntry]) -> [CallAnalyticsEntry] {
+        struct Key: Hashable {
+            let kind: CallKind
+            let name: String
+            let server: String?
+            let dayKey: String
+        }
+        struct Agg {
+            var count = 0
+            var outcomeKnown = 0
+            var success = 0
+            var durationSamples = 0
+            var durationMsTotal = 0.0
+        }
+
+        var counts: [Key: Agg] = [:]
+        for entry in entries {
+            let key = Key(kind: entry.kind, name: entry.name, server: entry.server, dayKey: entry.dayKey)
+            var agg = counts[key] ?? Agg()
+            agg.count += 1
+            if let success = entry.success {
+                agg.outcomeKnown += 1
+                if success { agg.success += 1 }
+            }
+            if let durationMs = entry.durationMs, durationMs >= 0 {
+                agg.durationSamples += 1
+                agg.durationMsTotal += durationMs
+            }
+            counts[key] = agg
+        }
+
+        return counts.map { key, agg in
+            CallAnalyticsEntry(
+                source: .opencode,
+                kind: key.kind,
+                name: key.name,
+                server: key.server,
+                agent: nil,
+                dayKey: key.dayKey,
+                count: agg.count,
+                outcomeKnownCount: agg.outcomeKnown,
+                successCount: agg.success,
+                durationSampleCount: agg.durationSamples,
+                durationMsTotal: agg.durationMsTotal
+            )
+        }
+    }
+
+    // MARK: - Disk
+
+    private func load() -> OpenCodeCallLedger {
+        if let cached { return cached }
+
+        if let data = try? Data(contentsOf: Self.fileURL(homeDirectory: homeDirectory)),
+           let decoded = try? JSONDecoder().decode(OpenCodeCallLedger.self, from: data),
+           decoded.version == Self.artifactVersion {
+            cached = decoded
+            return decoded
+        }
+
+        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil)
+        cached = fresh
+        return fresh
+    }
+
+    private func save(_ ledger: OpenCodeCallLedger) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(ledger)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            openCodeCallLedgerLog.warning("Failed to save opencode call ledger: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    static func fileURL(homeDirectory: String) -> URL {
+        let dir = (homeDirectory as NSString).appendingPathComponent(".config/aiusage/usage-archive")
+        return URL(fileURLWithPath: dir, isDirectory: true)
+            .appendingPathComponent("opencode-call-ledger-v\(artifactVersion).json")
+    }
+}

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
@@ -37,15 +37,6 @@ extension OpenCodeCostProvider {
 
     // MARK: Aggregation
 
-    /// rows → 按日聚合桶。
-    func buildDays(rows: [CodexRow]) -> [String: CodexAggregateBucket] {
-        var days: [String: CodexAggregateBucket] = [:]
-        for row in rows {
-            days[row.dayKey, default: .empty].record(row: row)
-        }
-        return days
-    }
-
     func aggregateDays(
         _ bucketsByDay: [String: CodexAggregateBucket],
         matching: (String) -> Bool

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
@@ -13,6 +13,7 @@ extension OpenCodeCostProvider {
 
     /// message 表的一行原始数据（data 为 OpenCode 的消息 JSON）。
     struct MessageRow: Sendable {
+        let messageId: String
         let sessionId: String
         let timeCreatedMillis: Int64
         let data: Data
@@ -28,7 +29,7 @@ extension OpenCodeCostProvider {
         }
         defer { sqlite3_close(db) }
 
-        var sql = "SELECT session_id, time_created, data FROM message"
+        var sql = "SELECT id, session_id, time_created, data FROM message"
         if sinceMillis != nil {
             sql += " WHERE time_created >= ?"
         }
@@ -53,13 +54,15 @@ extension OpenCodeCostProvider {
                 throw ProviderError("db_step_failed", SensitiveDataRedactor.redactPaths(in: message))
             }
 
-            guard let sessionCString = sqlite3_column_text(statement, 0),
-                  let dataCString = sqlite3_column_text(statement, 2) else {
+            guard let idCString = sqlite3_column_text(statement, 0),
+                  let sessionCString = sqlite3_column_text(statement, 1),
+                  let dataCString = sqlite3_column_text(statement, 3) else {
                 continue
             }
             rows.append(MessageRow(
+                messageId: String(cString: idCString),
                 sessionId: String(cString: sessionCString),
-                timeCreatedMillis: sqlite3_column_int64(statement, 1),
+                timeCreatedMillis: sqlite3_column_int64(statement, 2),
                 data: Data(String(cString: dataCString).utf8)
             ))
         }

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
@@ -41,9 +41,10 @@ extension OpenCodeCostProvider {
     /// 这里排除以免在 OpenCode 用量/费用/热力图里被重复计数。per-node 受管键恒为 `aiusage-<slug>`，不受影响。
     static let globalProxyProviderID = "aiusage"
 
-    /// 解析一行 message；非 assistant、零用量或无法解码的行返回 nil。
+    /// 解析一行 message 为账本明细条目；非 assistant、零用量或无法解码的行返回 nil。
+    /// 保留 messageId/sessionId/timeCreatedMillis 用于增量账本去重与明细追溯（issue #67）。
     /// decoder 由调用方每次 fetch 创建一只并复用（避免逐行新建，也避免跨任务共享）。
-    func parseMessageRow(_ row: MessageRow, decoder: JSONDecoder) -> CodexRow? {
+    func parseLedgerEntry(_ row: MessageRow, decoder: JSONDecoder) -> OpenCodeLedgerEntry? {
         guard let message = try? decoder.decode(MessageData.self, from: row.data),
               message.role == "assistant" else {
             return nil
@@ -63,13 +64,16 @@ extension OpenCodeCostProvider {
         guard totalTokens > 0 || cost > 0 else { return nil }
 
         let createdAt = Date(timeIntervalSince1970: Double(row.timeCreatedMillis) / 1000)
-        return CodexRow(
+        return OpenCodeLedgerEntry(
+            messageId: row.messageId,
+            sessionId: row.sessionId,
+            timeCreatedMillis: row.timeCreatedMillis,
             dayKey: dayKey(createdAt),
             model: modelLabel(providerID: message.providerID, modelID: message.modelID),
             inputTokens: inputTokens,
+            outputTokens: outputTokens,
             cacheReadTokens: cacheReadTokens,
             cacheCreateTokens: cacheCreateTokens,
-            outputTokens: outputTokens,
             totalTokens: totalTokens,
             estimatedCostUsd: cost
         )

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -21,6 +21,8 @@ public struct OpenCodeCostProvider: ProviderFetcher {
 
     /// 永久每日归档（每个 home 一张，按 homeDirectory 区分以隔离测试 / 多配置）。
     static let archive = OpenCodeUsageArchiveStore()
+    /// 独立明细账本（message 级，按 message.id 去重增量），issue #67 的持久真相源。
+    static let ledger = OpenCodeLedgerStore()
     static let defaultScanDays = 30
 
     public init(
@@ -37,31 +39,35 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         let now = Date()
         let todayKey = dayKey(now)
 
-        // 首次（归档从未完成全量）触发全量扫描以冻结所有历史日；之后只扫窗口。
-        let shouldImportFullHistory = await Self.archive.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
+        // 首次（账本从未完成全量）触发全量扫描以回填账本全部明细；之后只扫窗口。
+        let shouldImportFullHistory = await Self.ledger.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
         let sinceMillis: Int64? = shouldImportFullHistory ? nil : scanWindowStartMillis(now: now)
 
-        // 1) 读库（OpenCode 未安装/版本过旧时跳过：冻结归档可能仍有历史数据）。
+        // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/版本过旧时跳过，账本仍有历史）。
         let dataDirectory = resolveDataDirectory()
-        var sessionIds = Set<String>()
-        var computed: [String: CodexAggregateBucket] = [:]
         if let dataDirectory {
             let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
             defer { cleanupDatabaseSnapshot(snapshotPath) }
             let messageRows = try fetchMessageRows(databasePath: snapshotPath, sinceMillis: sinceMillis)
             let decoder = JSONDecoder()
-            var rows: [CodexRow] = []
-            rows.reserveCapacity(messageRows.count)
+            var entries: [OpenCodeLedgerEntry] = []
+            entries.reserveCapacity(messageRows.count)
             for messageRow in messageRows {
-                guard let row = parseMessageRow(messageRow, decoder: decoder) else { continue }
-                rows.append(row)
-                sessionIds.insert(messageRow.sessionId)
+                guard let entry = parseLedgerEntry(messageRow, decoder: decoder) else { continue }
+                entries.append(entry)
             }
-            computed = buildDays(rows: rows)
+            await Self.ledger.merge(
+                homeDirectory: homeDirectory,
+                newEntries: entries,
+                completedFullHistory: shouldImportFullHistory
+            )
         }
         relieveMallocPressure()
 
-        // 2) 冻结归档：昨日前首写冻结、今天覆盖重算；删除本地库后历史不丢。
+        // 2) 账本聚合 → 冻结归档：昨日前首写冻结、今天从账本累积覆盖（删除会话后账本不删，统计不丢）。
+        let ledgerEntries = await Self.ledger.allEntries(homeDirectory: homeDirectory)
+        let sessionIds = Set(ledgerEntries.map { $0.sessionId })
+        let computed = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
         let dbDays = await Self.archive.freeze(
             homeDirectory: homeDirectory,
             computed: computed,

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+import os.log
+
+private let openCodeLedgerLog = Logger(subsystem: "com.aiusage.quotabackend", category: "OpenCodeLedger")
+
+// MARK: - OpenCode Ledger Store
+// OpenCode 本地会话用量的「独立明细账本」（issue #67）。
+// 与 usage-archive 的「日聚合冻结」不同，本账本按 message 级明细持久化，
+// 以 opencode.db message.id 为主键做 upsert，从而在 opencode 侧删除会话 / 清空历史后，
+// 已记录的 token/cost 明细仍可追溯、不丢失。
+//
+// 语义：
+// - upsert：本次扫描读到的 message（按 id）覆盖旧值——处理 opencode 流式过程中 token 数的渐进更新。
+// - 保留：本次扫描读不到的 message（opencode 侧已删除，或超出扫描窗口）不从账本删除——删除不丢账。
+//
+// 持久化（永久、放 ~/.config/aiusage 避免被系统清理）:
+//   <home>/.config/aiusage/usage-archive/opencode-ledger-v<version>.json
+// 与 usage-archive 同目录但独立文件，避免污染 Codex/Claude 共享的 CodexUsageArchive 结构。
+
+/// 一条 assistant 消息的完整用量明细（满足 issue #67「明细可追溯」：时间/模型/各类型 token/cost）。
+struct OpenCodeLedgerEntry: Codable, Sendable, Equatable {
+    /// opencode.db message.id（text 主键，如 `msg_xxx`），账本去重键。
+    let messageId: String
+    let sessionId: String
+    /// 消息创建时间（epoch 毫秒，来自 message.time_created）。
+    let timeCreatedMillis: Int64
+    /// 归属日（yyyy-MM-dd，解析时按 provider 时区固定，避免时区漂移）。
+    let dayKey: String
+    /// 模型名口径 `providerID/modelID`。
+    let model: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheCreateTokens: Int
+    let totalTokens: Int
+    /// models.dev 定价的冻结成本（订阅渠道恒 0，非「未定价」）。
+    let estimatedCostUsd: Double
+
+    func asCodexRow() -> CodexRow {
+        CodexRow(
+            dayKey: dayKey,
+            model: model,
+            inputTokens: inputTokens,
+            cacheReadTokens: cacheReadTokens,
+            cacheCreateTokens: cacheCreateTokens,
+            outputTokens: outputTokens,
+            totalTokens: totalTokens,
+            estimatedCostUsd: estimatedCostUsd
+        )
+    }
+}
+
+/// 账本文件结构（version 1）。
+struct OpenCodeLedger: Codable, Sendable {
+    let version: Int
+    var updatedAt: String
+    var entries: [String: OpenCodeLedgerEntry]
+    var fullHistoryImportedAt: String?
+}
+
+actor OpenCodeLedgerStore {
+    static let artifactVersion = 1
+
+    private var ledgers: [String: OpenCodeLedger] = [:]
+    private var loaded: Set<String> = []
+
+    /// 首次返回 true（触发一次全量扫描以回填账本全部明细），完成后恒 false。
+    func consumeFullHistoryImportRequest(homeDirectory: String) -> Bool {
+        load(homeDirectory).fullHistoryImportedAt == nil
+    }
+
+    /// 按 messageId upsert 合并本次读到的明细；账本中读不到的条目保留（删除不丢）。
+    /// 返回合并后的全部明细，供调用方聚合与 sessionCount 统计。
+    @discardableResult
+    func merge(
+        homeDirectory: String,
+        newEntries: [OpenCodeLedgerEntry],
+        completedFullHistory: Bool
+    ) -> [OpenCodeLedgerEntry] {
+        var ledger = load(homeDirectory)
+        var changed = false
+
+        for entry in newEntries {
+            if ledger.entries[entry.messageId] != entry {
+                ledger.entries[entry.messageId] = entry
+                changed = true
+            }
+        }
+
+        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
+            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+            changed = true
+        }
+
+        if changed {
+            ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+            ledgers[homeDirectory] = ledger
+            save(homeDirectory, ledger)
+        } else {
+            ledgers[homeDirectory] = ledger
+        }
+        return Array(ledger.entries.values)
+    }
+
+    /// 读取账本全部明细（不触发写）。
+    func allEntries(homeDirectory: String) -> [OpenCodeLedgerEntry] {
+        Array(load(homeDirectory).entries.values)
+    }
+
+    /// 从明细聚合日桶（复用 CodexAggregateBucket.record）。
+    static func aggregateDays(_ entries: [OpenCodeLedgerEntry]) -> [String: CodexAggregateBucket] {
+        var days: [String: CodexAggregateBucket] = [:]
+        for entry in entries {
+            days[entry.dayKey, default: .empty].record(row: entry.asCodexRow())
+        }
+        return days
+    }
+
+    // MARK: Disk
+
+    private func load(_ homeDirectory: String) -> OpenCodeLedger {
+        if let ledger = ledgers[homeDirectory], loaded.contains(homeDirectory) { return ledger }
+        loaded.insert(homeDirectory)
+
+        if let data = try? Data(contentsOf: Self.fileURL(homeDirectory: homeDirectory)),
+           let decoded = try? JSONDecoder().decode(OpenCodeLedger.self, from: data),
+           decoded.version == Self.artifactVersion {
+            ledgers[homeDirectory] = decoded
+            return decoded
+        }
+
+        let fresh = OpenCodeLedger(version: Self.artifactVersion, updatedAt: "", entries: [:])
+        ledgers[homeDirectory] = fresh
+        return fresh
+    }
+
+    private func save(_ homeDirectory: String, _ ledger: OpenCodeLedger) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(ledger)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            openCodeLedgerLog.warning("Failed to save OpenCode ledger: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    static func fileURL(homeDirectory: String) -> URL {
+        let dir = (homeDirectory as NSString).appendingPathComponent(".config/aiusage/usage-archive")
+        return URL(fileURLWithPath: dir, isDirectory: true)
+            .appendingPathComponent("opencode-ledger-v\(artifactVersion).json")
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+@testable import QuotaBackend
+
+final class OpenCodeCallLedgerStoreTests: XCTestCase {
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-call-ledger-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeEntry(
+        partId: String,
+        dayKey: String = "2026-09-07",
+        kind: CallKind = .builtin,
+        name: String = "bash",
+        server: String? = nil,
+        success: Bool? = true,
+        durationMs: Double? = 100
+    ) -> OpenCodeCallLedgerEntry {
+        OpenCodeCallLedgerEntry(
+            partId: partId,
+            dayKey: dayKey,
+            kind: kind,
+            name: name,
+            server: server,
+            success: success,
+            durationMs: durationMs
+        )
+    }
+
+    func testMergeAccumulatesNewEntriesAcrossBatches() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2")], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_3")], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(Set(all.map(\.partId)), ["prt_1", "prt_2", "prt_3"])
+    }
+
+    func testMergeRetainsEntriesNotInLaterBatch() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(
+            newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2"), makeEntry(partId: "prt_3")],
+            completedFullHistory: false
+        )
+        // 第二批只扫到 prt_1（prt_2、prt_3 对应会话被删除），账本应保留它们。
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(Set(all.map(\.partId)), ["prt_1", "prt_2", "prt_3"])
+    }
+
+    func testMergeUpdatesExistingEntryWithoutDoubleCounting() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: false, durationMs: 50)], completedFullHistory: false)
+        // 同一条 part 状态从 running 更新为 completed：应覆盖旧值而非新增一条。
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: true, durationMs: 200)], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all.first?.success, true)
+        XCTAssertEqual(all.first?.durationMs, 200)
+    }
+
+    func testAggregateGroupsByDayKey() {
+        let entries = [
+            makeEntry(partId: "prt_1", dayKey: "2026-09-06"),
+            makeEntry(partId: "prt_2", dayKey: "2026-09-07"),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+        XCTAssertEqual(Set(aggregated.map(\.dayKey)), ["2026-09-06", "2026-09-07"])
+    }
+
+    func testAggregateSumCountAndSignalsByKindAndName() {
+        let entries = [
+            makeEntry(partId: "prt_1", kind: .builtin, name: "bash", success: true, durationMs: 100),
+            makeEntry(partId: "prt_2", kind: .builtin, name: "bash", success: false, durationMs: 300),
+            makeEntry(partId: "prt_3", kind: .builtin, name: "read", success: nil, durationMs: nil),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+
+        let bash = aggregated.first { $0.name == "bash" }
+        XCTAssertEqual(bash?.count, 2)
+        XCTAssertEqual(bash?.outcomeKnownCount, 2)
+        XCTAssertEqual(bash?.successCount, 1)
+        XCTAssertEqual(bash?.durationSampleCount, 2)
+        XCTAssertEqual(bash?.durationMsTotal, 400)
+
+        let read = aggregated.first { $0.name == "read" }
+        XCTAssertEqual(read?.count, 1)
+        XCTAssertEqual(read?.outcomeKnownCount, 0)
+        XCTAssertEqual(read?.successCount, 0)
+        XCTAssertEqual(read?.durationSampleCount, 0)
+        XCTAssertEqual(read?.durationMsTotal, 0)
+    }
+
+    func testAggregateMCPKeepsServer() {
+        let entries = [
+            makeEntry(partId: "prt_1", kind: .mcp, name: "server/tool", server: "server"),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+        XCTAssertEqual(aggregated.count, 1)
+        XCTAssertEqual(aggregated.first?.server, "server")
+        XCTAssertEqual(aggregated.first?.source, .opencode)
+    }
+
+    func testFullHistoryImportFlagPersists() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: true)
+        XCTAssertTrue(store.fullHistoryImported)
+
+        // 重新实例化（模拟重启）后标记仍在。
+        let reopened = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+        XCTAssertTrue(reopened.fullHistoryImported)
+    }
+
+    func testFullHistoryImportFlagSetOnEmptyMerge() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [], completedFullHistory: true)
+        XCTAssertTrue(store.fullHistoryImported)
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import Foundation
+@testable import QuotaBackend
+
+final class OpenCodeLedgerStoreTests: XCTestCase {
+    func testMergeAccumulatesNewEntriesAcrossBatches() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        var days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 300)
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 2)
+
+        // 第二批：新 msg_3 + 更新 msg_2（同 id 覆盖）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+            entry(id: "msg_2", tokens: 250),
+        ], completedFullHistory: false)
+
+        days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 650)  // 100 + 250 + 300
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 3)
+    }
+
+    func testMergeRetainsEntriesNotInLaterBatch() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        // 模拟删除会话：第二批只含 msg_3（msg_1 已从 opencode.db 消失）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+        ], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 600)  // 100 + 200 + 300（msg_1 不丢）
+    }
+
+    func testMergeUpdatesExistingEntryWithoutDoubleCounting() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 100)], completedFullHistory: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 250)], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 250)  // 更新覆盖，不重复计数
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 1)
+    }
+
+    func testAggregateDaysGroupsByDayKey() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", tokens: 100),
+            entry(id: "msg_2", day: "2026-01-02", tokens: 200),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days.count, 2)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 100)
+        XCTAssertEqual(days["2026-01-02"]?.totalTokens, 200)
+    }
+
+    func testAggregateDaysSumCostAndTokensByModel() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", model: "anthropic/sonnet", tokens: 100, cost: 0.01),
+            entry(id: "msg_2", day: "2026-01-01", model: "anthropic/sonnet", tokens: 200, cost: 0.02),
+            entry(id: "msg_3", day: "2026-01-01", model: "openai/gpt-5", tokens: 300, cost: 0.03),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        let day = days["2026-01-01"]
+        XCTAssertEqual(day?.totalTokens, 600)
+        XCTAssertEqual(day?.estimatedCostUsd ?? 0, 0.06, accuracy: 0.0001)
+        XCTAssertEqual(day?.models.count, 2)
+        XCTAssertEqual(day?.models["anthropic/sonnet"]?.totalTokens, 300)
+        XCTAssertEqual(day?.models["openai/gpt-5"]?.totalTokens, 300)
+    }
+
+    func testFullHistoryImportFlagPersists() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        var shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertTrue(shouldImport)
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], completedFullHistory: true)
+
+        shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    func testFullHistoryImportFlagSetOnEmptyMerge() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        // 全量导入但 db 为空（无 assistant 消息）→ 仍标记已完成，避免每次重复全量扫描。
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], completedFullHistory: true)
+
+        let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    // MARK: Helpers
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-ledger-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func aggregatedDays(_ store: OpenCodeLedgerStore, home: String) async -> [String: CodexAggregateBucket] {
+        let entries = await store.allEntries(homeDirectory: home)
+        return OpenCodeLedgerStore.aggregateDays(entries)
+    }
+
+    private func entry(
+        id: String,
+        day: String = "2026-01-01",
+        model: String = "anthropic/claude-sonnet",
+        tokens: Int = 100,
+        cost: Double = 0.01
+    ) -> OpenCodeLedgerEntry {
+        OpenCodeLedgerEntry(
+            messageId: id,
+            sessionId: "sess-1",
+            timeCreatedMillis: 1_700_000_000_000,
+            dayKey: day,
+            model: model,
+            inputTokens: tokens,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreateTokens: 0,
+            totalTokens: tokens,
+            estimatedCostUsd: cost
+        )
+    }
+}


### PR DESCRIPTION
## 概述

修复 #67：OpenCode 用量数据由 AIUsage 自存储，不再依赖 opencode 会话，删除会话后统计不丢。

当前实现直接读 `opencode.db`，今天的数据每次刷新重算。opencode 删除会话/清空历史后，`message` 与 `part` 表对应行消失（含级联删除），导致 AIUsage 的「用量统计」和「调用分析」随之丢失。本 PR 引入两份独立明细账本，把每次刷新读取到的明细增量持久化，今天的数据也改从账本聚合，删除会话后已记录数据不受影响。

## 方案

新增两个明细账本（按稳定唯一 ID 去重 upsert，读不到的不删）：

1. **用量账本** `opencode-ledger-v1.json`：按 `message.id`（`msg_xxx`）去重，保存时间/模型/input/output/cache token/cost/会话归属。
2. **调用账本** `opencode-call-ledger-v1.json`：按 `part.id`（`prt_xxx`）去重，保存时间/调用类别/名称/成功与否/耗时。

两者均放在 `~/.config/aiusage/usage-archive/`，与既有冻结归档共存。

## 改动

- 新增 `Providers/OpenCodeLedgerStore.swift`（用量明细账本）
- 新增 `CallAnalytics/OpenCodeCallLedgerStore.swift`（调用明细账本）
- `OpenCodeCostProvider.swift` / `+Database.swift` / `+Parsing.swift`：读库改为输出含 `message.id` 的明细，`fetchUsage` 走账本聚合
- `CallAnalytics/OpenCodeCallEventSource.swift`：part 查询加 `id` 列，输出明细条目
- `CallAnalytics/CallAnalyticsEngine.swift`：opencode 源改为账本聚合，不再覆盖重算
- 新增 `OpenCodeLedgerStoreTests.swift`、`OpenCodeCallLedgerStoreTests.swift`（共 15 个用例，覆盖增量去重、删除会话不丢、更新不重复计数、按日/按模型聚合等）

## 验证

- 本机 `swift build` 通过。
- CI（fork）`Run QuotaBackend tests` 通过，全部用例 0 失败。
- 已人工验证：删除 opencode 会话后，用量统计与调用分析数据均不丢失。

## 兼容性

- 账本为增量持久化，不修改既有冻结归档 `opencode-usage-v1.json` 的文件格式与逻辑，Claude/Codex 统计不受影响。
- 迁移限制：账本只能保护升级后产生的数据，升级前已删除的会话无法恢复（在代码注释中说明）。

Closes https://github.com/sylearn/AIUsage/issues/67
