### PR TITLE
feat(opencode): 支持按模型追加任意参数

### DIFF
--- a/AIUsage.xcodeproj/project.pbxproj
+++ b/AIUsage.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		C1AA000100000000000000B1 /* JSONWebEditorAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */; };
 		C1AA000200000000000000B2 /* ProxyConfigEditorView+JSONTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */; };
 		C1AA000300000000000000B3 /* ProxyModelLibraryEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */; };
+		C1AA000500000000000000B5 /* ModelExtraParametersEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */; };
 		C1AA000400000000000000B4 /* PublicModelPricingImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000400000000000000A4 /* PublicModelPricingImport.swift */; };
 		C1AV00012FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AV00022FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift */; };
 		C1CA00022FCA005000B26789 /* CallAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CA00012FCA005000B26789 /* CallAnalyticsStore.swift */; };
@@ -352,6 +353,7 @@
 		C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONWebEditorAssets.swift; sourceTree = "<group>"; };
 		C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProxyConfigEditorView+JSONTab.swift"; sourceTree = "<group>"; };
 		C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyModelLibraryEditor.swift; sourceTree = "<group>"; };
+		C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelExtraParametersEditor.swift; sourceTree = "<group>"; };
 		C1AA000400000000000000A4 /* PublicModelPricingImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicModelPricingImport.swift; sourceTree = "<group>"; };
 		C1AV00022FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeNodeAvailabilitySection.swift; sourceTree = "<group>"; };
 		C1CA00012FCA005000B26789 /* CallAnalyticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAnalyticsStore.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */,
 				C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */,
 				C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */,
+				C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */,
 				C1AA000400000000000000A4 /* PublicModelPricingImport.swift */,
 				5EF87F062F8D0EED002FE291 /* ProxyManagementView.swift */,
 				C1CDH0022FD1000300B26789 /* ClaudeHubView.swift */,
@@ -995,6 +998,7 @@
 				C1AA000100000000000000B1 /* JSONWebEditorAssets.swift in Sources */,
 				C1AA000200000000000000B2 /* ProxyConfigEditorView+JSONTab.swift in Sources */,
 				C1AA000300000000000000B3 /* ProxyModelLibraryEditor.swift in Sources */,
+				C1AA000500000000000000B5 /* ModelExtraParametersEditor.swift in Sources */,
 				C1AA000400000000000000B4 /* PublicModelPricingImport.swift in Sources */,
 				5EF87F082F8D0EED002FE291 /* ProxyManagementView.swift in Sources */,
 				C1CDH0012FD1000300B26789 /* ClaudeHubView.swift in Sources */,

--- a/AIUsage/Models/OpenCodeNode.swift
+++ b/AIUsage/Models/OpenCodeNode.swift
@@ -70,6 +70,10 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
     /// 每模型输入/输出模态（空 = 不写 modalities，由 OpenCode 取模型默认）。
     var inputModalities: [OpenCodeModality]
     var outputModalities: [OpenCodeModality]
+    /// 每模型追加的任意 key-value 参数（值存字符串，生成时智能解析为 JSON 标量/对象/数组）。
+    /// key 支持点路径（如 "limit.context"）或顶级键（如 "temperature"）；生成 opencode.json 时
+    /// 按路径合并到该模型配置对象，覆盖节点级默认（issue #69）。空 = 不追加。
+    var extraParameters: [String: String]
 
     init(
         id: String,
@@ -79,7 +83,8 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         priceCacheWritePerMillion: Double = 0,
         pricingSource: ProxyConfiguration.ModelPricing.Source? = nil,
         inputModalities: [OpenCodeModality] = [],
-        outputModalities: [OpenCodeModality] = []
+        outputModalities: [OpenCodeModality] = [],
+        extraParameters: [String: String] = [:]
     ) {
         self.id = id
         self.priceInputPerMillion = priceInputPerMillion
@@ -89,6 +94,7 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         self.pricingSource = pricingSource
         self.inputModalities = inputModalities
         self.outputModalities = outputModalities
+        self.extraParameters = extraParameters
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -100,9 +106,10 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         case pricingSource
         case inputModalities
         case outputModalities
+        case extraParameters
     }
 
-    // 自定义解码：modalities 为后加字段，旧档案缺省 → 空数组，保证既有节点平滑升级。
+    // 自定义解码：modalities / extraParameters 为后加字段，旧档案缺省 → 空，保证既有节点平滑升级。
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(String.self, forKey: .id)
@@ -116,6 +123,7 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         )
         inputModalities = try c.decodeIfPresent([OpenCodeModality].self, forKey: .inputModalities) ?? []
         outputModalities = try c.decodeIfPresent([OpenCodeModality].self, forKey: .outputModalities) ?? []
+        extraParameters = try c.decodeIfPresent([String: String].self, forKey: .extraParameters) ?? [:]
     }
 
     var hasPricing: Bool {

--- a/AIUsage/Models/ProxyConfiguration.swift
+++ b/AIUsage/Models/ProxyConfiguration.swift
@@ -228,10 +228,26 @@ struct ProxyConfiguration: Codable, Identifiable, Equatable {
     struct MappedModel: Codable, Equatable {
         var name: String
         var pricing: ModelPricing
+        /// 每模型追加的任意 key-value 参数（生成 opencode.json 时合并到该模型配置，覆盖节点级默认）。
+        /// 值存字符串、生成时智能解析；与 OpenCodeModelEntry.extraParameters 同构（issue #69）。
+        var extraParameters: [String: String]
 
-        init(name: String, pricing: ModelPricing = .zero) {
+        init(name: String, pricing: ModelPricing = .zero, extraParameters: [String: String] = [:]) {
             self.name = name
             self.pricing = pricing
+            self.extraParameters = extraParameters
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name, pricing, extraParameters
+        }
+
+        // 自定义解码：extraParameters 为后加字段，旧档案缺省 → 空字典，保证既有 provider 平滑升级。
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            name = try c.decode(String.self, forKey: .name)
+            pricing = try c.decode(ModelPricing.self, forKey: .pricing)
+            extraParameters = try c.decodeIfPresent([String: String].self, forKey: .extraParameters) ?? [:]
         }
     }
 

--- a/AIUsage/ViewModels/APIProviderDistributor.swift
+++ b/AIUsage/ViewModels/APIProviderDistributor.swift
@@ -420,7 +420,8 @@ final class APIProviderDistributor {
                 priceOutputPerMillion: m.pricing.outputPerMillionUSD,
                 priceCacheReadPerMillion: m.pricing.cacheReadPerMillionUSD,
                 priceCacheWritePerMillion: m.pricing.cacheCreatePerMillionUSD,
-                pricingSource: m.pricing.source
+                pricingSource: m.pricing.source,
+                extraParameters: m.extraParameters
             )
         }
     }

--- a/AIUsage/ViewModels/OpenCodeConfigManager.swift
+++ b/AIUsage/ViewModels/OpenCodeConfigManager.swift
@@ -620,6 +620,11 @@ final class OpenCodeConfigManager {
                 }
                 entry["cost"] = costBlock
             }
+            // 每模型追加参数（issue #69）：在节点级默认 limit/options 写入之后按点路径合并，
+            // 覆盖节点级默认值，实现 per-model 独立配置。
+            if !model.extraParameters.isEmpty {
+                entry = Self.applyExtraParameters(model.extraParameters, to: entry)
+            }
             modelsBlock[model.id] = entry
         }
 
@@ -662,6 +667,59 @@ final class OpenCodeConfigManager {
         root["provider"] = provider
         root["model"] = "\(managedId)/\(defaultModel)"
         return root
+    }
+
+    /// 把每模型追加参数按点路径合并进模型 entry，覆盖节点级默认（issue #69）。
+    /// 值存字符串，此处智能解析为 JSON 标量/对象/数组后写入。
+    nonisolated static func applyExtraParameters(
+        _ parameters: [String: String],
+        to entry: [String: Any]
+    ) -> [String: Any] {
+        var result = entry
+        for (key, rawValue) in parameters {
+            guard let value = parseParameterValue(rawValue) else { continue }
+            setNestedValue(value, atPath: key, in: &result)
+        }
+        return result
+    }
+
+    /// 把字符串值解析为 JSON 值：整数/浮点/布尔/null 字面量、`{...}`/`[...]` 走 JSON 解析，
+    /// 其余原样保留为字符串。
+    nonisolated static func parseParameterValue(_ rawValue: String) -> Any? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        if let intValue = Int(trimmed) { return intValue }
+        if let doubleValue = Double(trimmed), trimmed.contains(".") { return doubleValue }
+        switch trimmed.lowercased() {
+        case "true": return true
+        case "false": return false
+        case "null", "nil": return NSNull()
+        default: break
+        }
+        if trimmed.hasPrefix("{") || trimmed.hasPrefix("[") {
+            if let data = trimmed.data(using: .utf8),
+               let object = try? JSONSerialization.jsonObject(with: data) {
+                return object
+            }
+        }
+        return rawValue
+    }
+
+    /// 按点路径（如 "limit.context"）把值写入嵌套字典；多段 key 逐层创建中间字典。
+    nonisolated static func setNestedValue(
+        _ value: Any,
+        atPath path: String,
+        in dict: inout [String: Any]
+    ) {
+        let components = path.split(separator: ".").map(String.init).filter { !$0.isEmpty }
+        guard let first = components.first else { return }
+        if components.count == 1 {
+            dict[first] = value
+            return
+        }
+        var child = dict[first] as? [String: Any] ?? [:]
+        setNestedValue(value, atPath: components.dropFirst().joined(separator: "."), in: &child)
+        dict[first] = child
     }
 
     /// 当前全局层的合并结果。接管目标使用备份中的原始内容，其他低优先级层按

--- a/AIUsage/Views/ModelExtraParametersEditor.swift
+++ b/AIUsage/Views/ModelExtraParametersEditor.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// 可复用的 per-model key-value 参数编辑器（issue #69）。
+/// 编辑 `[String: String]` 形式的任意追加参数，供 OpenCode 节点模型行与
+/// 统一 API Provider 模型库两处复用；值存字符串，生成时由配置管理器智能解析。
+struct ModelExtraParametersEditor: View {
+    @Binding var parameters: [String: String]
+    @State private var rows: [Row] = []
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var key = ""
+        var value = ""
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach($rows) { $row in
+                HStack(spacing: 6) {
+                    TextField(L("key", "键"), text: $row.key)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled()
+                    TextField(L("value", "值"), text: $row.value)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled()
+                    Button {
+                        rows.removeAll { $0.id == $row.wrappedValue.id }
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.red.opacity(0.7))
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: 20)
+                    .help(L("Remove parameter", "移除参数"))
+                }
+            }
+            Button {
+                rows.append(Row())
+            } label: {
+                Label(L("Add parameter", "添加参数"), systemImage: "plus.circle")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+        }
+        .onAppear { loadIfNeeded() }
+        .onChange(of: rows) { _, _ in persist() }
+    }
+
+    private func loadIfNeeded() {
+        guard rows.isEmpty else { return }
+        rows = parameters
+            .map { Row(key: $0.key, value: $0.value) }
+            .sorted { $0.key < $1.key }
+    }
+
+    private func persist() {
+        var next: [String: String] = [:]
+        for row in rows {
+            let key = row.key.trimmingCharacters(in: .whitespaces)
+            if !key.isEmpty { next[key] = row.value }
+        }
+        if next != parameters { parameters = next }
+    }
+}

--- a/AIUsage/Views/OpenCodeNodeEditorView.swift
+++ b/AIUsage/Views/OpenCodeNodeEditorView.swift
@@ -442,6 +442,7 @@ struct OpenCodeNodeEditorView: View {
         let rowId = row.wrappedValue.id
         let isExpanded = expandedModalityRows.contains(rowId)
         let hasModalities = row.wrappedValue.entry.hasModalities
+        let hasExtraParameters = !row.wrappedValue.entry.extraParameters.isEmpty
         return VStack(spacing: 6) {
             HStack(spacing: 6) {
                 Button {
@@ -478,13 +479,14 @@ struct OpenCodeNodeEditorView: View {
                     if isExpanded { expandedModalityRows.remove(rowId) }
                     else { expandedModalityRows.insert(rowId) }
                 } label: {
-                    Image(systemName: hasModalities ? "square.stack.3d.up.fill" : "square.stack.3d.up")
+                    let hasAdvanced = hasModalities || hasExtraParameters
+                    Image(systemName: hasAdvanced ? "square.stack.3d.up.fill" : "square.stack.3d.up")
                         .font(.system(size: 12))
-                        .foregroundStyle(hasModalities ? Self.brand : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
+                        .foregroundStyle(hasAdvanced ? Self.brand : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
                 }
                 .buttonStyle(.plain)
                 .frame(width: 20)
-                .help(L("Configure modalities for this model", "为该模型配置模态（输入/输出）"))
+                .help(L("Configure advanced options for this model", "为该模型配置模态与追加参数"))
 
                 Button {
                     modelRows.removeAll { $0.id == row.wrappedValue.id }
@@ -506,7 +508,7 @@ struct OpenCodeNodeEditorView: View {
         }
     }
 
-    /// 单个模型的 modalities 配置面板：输入/输出两组可多选的模态芯片（issue #24）。
+    /// 单个模型的高级配置面板：modalities（输入/输出模态）+ 任意追加参数（issue #24 / #69）。
     private func modalityEditor(_ row: Binding<OpenCodeNodeEditorView.ModelRow>) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             modalityRow(
@@ -522,6 +524,18 @@ struct OpenCodeNodeEditorView: View {
             Text(L(
                 "Leave empty to use the model's defaults. Written into the model's modalities block in the active OpenCode config.",
                 "留空则使用模型默认值。会写入当前 OpenCode 配置中该模型的 modalities 块。"
+            ))
+            .font(.system(size: 10))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+            Divider()
+            Text(L("Extra parameters", "追加参数"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            ModelExtraParametersEditor(parameters: row.entry.extraParameters)
+            Text(L(
+                "Keys support dot paths (e.g. \"limit.context\") or top-level keys (e.g. \"temperature\"). Written into this model's config, overriding node-level defaults.",
+                "键支持点路径（如 \"limit.context\"）或顶级键（如 \"temperature\"），会写入该模型配置并覆盖节点级默认值。"
             ))
             .font(.system(size: 10))
             .foregroundStyle(.tertiary)

--- a/AIUsage/Views/ProxyModelLibraryEditor.swift
+++ b/AIUsage/Views/ProxyModelLibraryEditor.swift
@@ -546,6 +546,7 @@ struct ProviderModelLibraryEditor: View {
     }
 
     @State private var rows: [Row]
+    @State private var expandedExtraRows: Set<UUID> = []
 
     init(
         library: Binding<[ProxyConfiguration.MappedModel]>,
@@ -647,7 +648,11 @@ struct ProviderModelLibraryEditor: View {
     private var rowsFingerprint: [String] {
         rows.map { row in
             let p = row.model.pricing
-            return "\(row.model.name)|\(p.inputPerMillion)|\(p.outputPerMillion)|\(p.cacheCreatePerMillion)|\(p.cacheReadPerMillion)|\(p.currency.rawValue)|\(p.source?.kind.rawValue ?? "")"
+            let extra = row.model.extraParameters
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: ",")
+            return "\(row.model.name)|\(p.inputPerMillion)|\(p.outputPerMillion)|\(p.cacheCreatePerMillion)|\(p.cacheReadPerMillion)|\(p.currency.rawValue)|\(p.source?.kind.rawValue ?? "")|\(extra)"
         }
     }
 
@@ -666,35 +671,71 @@ struct ProviderModelLibraryEditor: View {
             }
             .frame(width: 64, alignment: .leading)
             Text(L("Source", "来源")).frame(width: 60, alignment: .leading)
-            Spacer().frame(width: 20)
+            Spacer().frame(width: 40)
         }
         .font(.system(size: 10, weight: .medium))
         .foregroundStyle(.tertiary)
     }
 
     private func rowView(_ row: Binding<Row>) -> some View {
-        HStack(spacing: 6) {
-            TextField("gpt-5.5", text: row.model.name)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12, design: .monospaced))
-                .frame(minWidth: 0, maxWidth: .infinity)
-                .layoutPriority(1)
-                .autocorrectionDisabled()
-            providerPriceField(row.model.pricing.inputPerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.outputPerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.cacheCreatePerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.cacheReadPerMillion, pricing: row.model.pricing)
-            PricingSourceIndicator(pricing: row.wrappedValue.model.pricing, width: 60)
-            Button {
-                rows.removeAll { $0.id == row.wrappedValue.id }
-            } label: {
-                Image(systemName: "minus.circle.fill")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.red.opacity(0.7))
+        let rowId = row.wrappedValue.id
+        let isExpanded = expandedExtraRows.contains(rowId)
+        let hasExtra = !row.wrappedValue.model.extraParameters.isEmpty
+        return VStack(spacing: 6) {
+            HStack(spacing: 6) {
+                TextField("gpt-5.5", text: row.model.name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .layoutPriority(1)
+                    .autocorrectionDisabled()
+                providerPriceField(row.model.pricing.inputPerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.outputPerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.cacheCreatePerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.cacheReadPerMillion, pricing: row.model.pricing)
+                PricingSourceIndicator(pricing: row.wrappedValue.model.pricing, width: 60)
+                Button {
+                    if isExpanded { expandedExtraRows.remove(rowId) }
+                    else { expandedExtraRows.insert(rowId) }
+                } label: {
+                    Image(systemName: hasExtra ? "gearshape.2.fill" : "gearshape.2")
+                        .font(.system(size: 12))
+                        .foregroundStyle(hasExtra ? Color.accentColor : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 20)
+                .help(L("Configure extra parameters for this model", "为该模型配置追加参数"))
+                Button {
+                    rows.removeAll { $0.id == rowId }
+                    expandedExtraRows.remove(rowId)
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.red.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 20)
+                .help(L("Remove provider model", "移除提供商模型"))
             }
-            .buttonStyle(.plain)
-            .frame(width: 20)
-            .help(L("Remove provider model", "移除提供商模型"))
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    ModelExtraParametersEditor(parameters: row.model.extraParameters)
+                    Text(L(
+                        "Keys support dot paths (e.g. \"limit.context\") or top-level keys (e.g. \"temperature\"). Written into this model's config, overriding node-level defaults.",
+                        "键支持点路径（如 \"limit.context\"）或顶级键（如 \"temperature\"），会写入该模型配置并覆盖节点级默认值。"
+                    ))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.primary.opacity(0.04))
+                )
+                .padding(.leading, 24)
+            }
         }
     }
 


### PR DESCRIPTION
## 概述

支持按模型独立追加任意 key-value 参数（如 `limit.context`），对齐 opencode 原生 `models[name].<key>` 语义。参考 cc-switch 的 per-model 配置思路，但不固定参数名——任意键值对都可追加到模型配置。

Closes #69

## 问题

当前 `contextLimit` / `outputLimit` 是节点级字段，`managedProviderEntry` 对所有模型写同一值。同节点不同模型上下文窗口不同：写统一值会把大窗口模型限小、小窗口模型超限；不写（0）则 opencode 拿不到窗口信息（日志 `contextLimit=NONE`，依赖窗口的压缩插件失效）。

## 方案

- 数据结构：`OpenCodeModelEntry` 与 `MappedModel` 各加 `extraParameters: [String: String]`（值存字符串，解码缺省空字典，旧档案平滑升级）。
- 生成：`managedProviderEntry` 在节点级默认 limit/options 写入**之后**深合并 per-model 参数，覆盖节点级默认。新增 `applyExtraParameters` / `parseParameterValue` / `setNestedValue` 三个辅助方法。
- 键语义：支持点路径（`limit.context` → `entry["limit"]["context"]`）与顶级键（`temperature` → `entry["temperature"]`）。
- 值语义：智能解析——纯整数→Int、浮点→Double、true/false→Bool、null→NSNull、`{...}`/`[...]`→JSON 对象/数组、其余→字符串。
- 分发：`APIProviderDistributor.openCodeEntries` 透传 `extraParameters`，统一 API Provider 的模型库参数随分发进入 OpenCode 配置。
- UI：新增可复用 `ModelExtraParametersEditor`（key-value 列表），接入两处——OpenCode 节点模型行展开面板 + API Provider 模型库行展开面板。

## 改动

- `AIUsage/Models/OpenCodeNode.swift` — OpenCodeModelEntry.extraParameters
- `AIUsage/Models/ProxyConfiguration.swift` — MappedModel.extraParameters
- `AIUsage/ViewModels/OpenCodeConfigManager.swift` — applyExtraParameters/parseParameterValue/setNestedValue
- `AIUsage/ViewModels/APIProviderDistributor.swift` — openCodeEntries 映射
- `AIUsage/Views/ModelExtraParametersEditor.swift` — 新增可复用组件
- `AIUsage/Views/OpenCodeNodeEditorView.swift` — 模型行展开面板接入
- `AIUsage/Views/ProxyModelLibraryEditor.swift` — 模型库行展开面板接入
- `AIUsage.xcodeproj/project.pbxproj` — 登记新文件

## 验证

CI 编译通过（Run QuotaBackend tests + Claude proxy regression 均 success）。节点级 contextLimit/outputLimit 保留作 fallback，per-model 参数优先，向后兼容。\n