### PR TITLE
feat(opencode): 用量账本 + 多节点 + 模型参数 + 调用分析后台同步（收口 #71–#73）

### DIFF
--- a/AIUsage.xcodeproj/project.pbxproj
+++ b/AIUsage.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		C1AA000100000000000000B1 /* JSONWebEditorAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */; };
 		C1AA000200000000000000B2 /* ProxyConfigEditorView+JSONTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */; };
 		C1AA000300000000000000B3 /* ProxyModelLibraryEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */; };
+		C1AA000500000000000000B5 /* ModelExtraParametersEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */; };
 		C1AA000400000000000000B4 /* PublicModelPricingImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA000400000000000000A4 /* PublicModelPricingImport.swift */; };
 		C1AV00012FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AV00022FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift */; };
 		C1CA00022FCA005000B26789 /* CallAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CA00012FCA005000B26789 /* CallAnalyticsStore.swift */; };
@@ -352,6 +353,7 @@
 		C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONWebEditorAssets.swift; sourceTree = "<group>"; };
 		C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProxyConfigEditorView+JSONTab.swift"; sourceTree = "<group>"; };
 		C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyModelLibraryEditor.swift; sourceTree = "<group>"; };
+		C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelExtraParametersEditor.swift; sourceTree = "<group>"; };
 		C1AA000400000000000000A4 /* PublicModelPricingImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicModelPricingImport.swift; sourceTree = "<group>"; };
 		C1AV00022FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeNodeAvailabilitySection.swift; sourceTree = "<group>"; };
 		C1CA00012FCA005000B26789 /* CallAnalyticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAnalyticsStore.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				C1AA000100000000000000A1 /* JSONWebEditorAssets.swift */,
 				C1AA000200000000000000A2 /* ProxyConfigEditorView+JSONTab.swift */,
 				C1AA000300000000000000A3 /* ProxyModelLibraryEditor.swift */,
+				C1AA000500000000000000A5 /* ModelExtraParametersEditor.swift */,
 				C1AA000400000000000000A4 /* PublicModelPricingImport.swift */,
 				5EF87F062F8D0EED002FE291 /* ProxyManagementView.swift */,
 				C1CDH0022FD1000300B26789 /* ClaudeHubView.swift */,
@@ -995,6 +998,7 @@
 				C1AA000100000000000000B1 /* JSONWebEditorAssets.swift in Sources */,
 				C1AA000200000000000000B2 /* ProxyConfigEditorView+JSONTab.swift in Sources */,
 				C1AA000300000000000000B3 /* ProxyModelLibraryEditor.swift in Sources */,
+				C1AA000500000000000000B5 /* ModelExtraParametersEditor.swift in Sources */,
 				C1AA000400000000000000B4 /* PublicModelPricingImport.swift in Sources */,
 				5EF87F082F8D0EED002FE291 /* ProxyManagementView.swift in Sources */,
 				C1CDH0012FD1000300B26789 /* ClaudeHubView.swift in Sources */,

--- a/AIUsage.xcodeproj/project.pbxproj
+++ b/AIUsage.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		C1OE001A2FB0004000B26789 /* OpenCodeConnectivityTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE00192FB0004000B26789 /* OpenCodeConnectivityTester.swift */; };
 		C1OE001C2FB0004000B26789 /* OpenCodeManagementView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE001B2FB0004000B26789 /* OpenCodeManagementView+Toolbar.swift */; };
 		C1OE001E2FB0005000B26789 /* OpenCodeGlobalConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE001D2FB0005000B26789 /* OpenCodeGlobalConfigSection.swift */; };
+		C1OE00262FB0005000B26789 /* OpenCodeDefaultModelNodeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE00252FB0005000B26789 /* OpenCodeDefaultModelNodeSection.swift */; };
 		C1OE00222FB0006000B26789 /* OpenCodeNodeStore+CCSwitchSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE00212FB0006000B26789 /* OpenCodeNodeStore+CCSwitchSync.swift */; };
 		C1OE00242FB0007000B26789 /* CCSwitchLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1OE00232FB0007000B26789 /* CCSwitchLocator.swift */; };
 		C1PE00022FB0000500B26789 /* ProxyEditorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1PE00012FB0000500B26789 /* ProxyEditorControls.swift */; };
@@ -430,6 +431,7 @@
 		C1OE00192FB0004000B26789 /* OpenCodeConnectivityTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeConnectivityTester.swift; sourceTree = "<group>"; };
 		C1OE001B2FB0004000B26789 /* OpenCodeManagementView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OpenCodeManagementView+Toolbar.swift"; sourceTree = "<group>"; };
 		C1OE001D2FB0005000B26789 /* OpenCodeGlobalConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeGlobalConfigSection.swift; sourceTree = "<group>"; };
+		C1OE00252FB0005000B26789 /* OpenCodeDefaultModelNodeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeDefaultModelNodeSection.swift; sourceTree = "<group>"; };
 		C1OE00212FB0006000B26789 /* OpenCodeNodeStore+CCSwitchSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OpenCodeNodeStore+CCSwitchSync.swift"; sourceTree = "<group>"; };
 		C1OE00232FB0007000B26789 /* CCSwitchLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCSwitchLocator.swift; sourceTree = "<group>"; };
 		C1PE00012FB0000500B26789 /* ProxyEditorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyEditorControls.swift; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 				C1OE00172FB0004000B26789 /* OpenCodeNodeStatsSection.swift */,
 				C1AV00022FB0004000B26789 /* OpenCodeNodeAvailabilitySection.swift */,
 				C1OE001D2FB0005000B26789 /* OpenCodeGlobalConfigSection.swift */,
+				C1OE00252FB0005000B26789 /* OpenCodeDefaultModelNodeSection.swift */,
 				C1MB00052FB0000400B26789 /* MenuBarAccountRow.swift */,
 				C1MB00072FB0000400B26789 /* MenuBarRows.swift */,
 				C1MB00092FB0000400B26789 /* MenuBarSupport.swift */,
@@ -965,6 +968,7 @@
 				C1OE00122FB0003000B26789 /* ModelSuggestionField.swift in Sources */,
 				C1OE001A2FB0004000B26789 /* OpenCodeConnectivityTester.swift in Sources */,
 				C1OE001E2FB0005000B26789 /* OpenCodeGlobalConfigSection.swift in Sources */,
+				C1OE00262FB0005000B26789 /* OpenCodeDefaultModelNodeSection.swift in Sources */,
 				C1OE00142FB0004000B26789 /* OpenCodeNodeStatsStore.swift in Sources */,
 				C1CA00022FCA005000B26789 /* CallAnalyticsStore.swift in Sources */,
 				C1CA00042FCA005000B26789 /* CallAnalyticsView.swift in Sources */,

--- a/AIUsage/Models/GlobalConfig.swift
+++ b/AIUsage/Models/GlobalConfig.swift
@@ -9,6 +9,15 @@ import Foundation
 struct GlobalConfig {
     var enabled: Bool
     var settings: [String: Any]
+    /// OpenCode 代理「通用配置」中显式选择的默认节点（顶层 model 指向它）。
+    /// nil 表示未显式选择，重写受管配置时回退到第一个激活节点。
+    var openCodeDefaultNodeId: String?
+
+    init(enabled: Bool, settings: [String: Any], openCodeDefaultNodeId: String? = nil) {
+        self.enabled = enabled
+        self.settings = settings
+        self.openCodeDefaultNodeId = openCodeDefaultNodeId
+    }
 
     static let empty = GlobalConfig(enabled: false, settings: [:])
 
@@ -35,10 +44,13 @@ struct GlobalConfig {
     // MARK: - Serialize / Deserialize
 
     func toFileData() throws -> Data {
-        let root: [String: Any] = [
+        var root: [String: Any] = [
             "enabled": enabled,
             "settings": settings,
         ]
+        if let nodeId = openCodeDefaultNodeId {
+            root["openCodeDefaultNodeId"] = nodeId
+        }
         return try JSONSerialization.data(
             withJSONObject: root,
             options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
@@ -51,6 +63,7 @@ struct GlobalConfig {
         }
         let enabled = root["enabled"] as? Bool ?? false
         let settings = root["settings"] as? [String: Any] ?? [:]
-        return GlobalConfig(enabled: enabled, settings: settings)
+        let openCodeDefaultNodeId = root["openCodeDefaultNodeId"] as? String
+        return GlobalConfig(enabled: enabled, settings: settings, openCodeDefaultNodeId: openCodeDefaultNodeId)
     }
 }

--- a/AIUsage/Models/GlobalConfig.swift
+++ b/AIUsage/Models/GlobalConfig.swift
@@ -9,14 +9,10 @@ import Foundation
 struct GlobalConfig {
     var enabled: Bool
     var settings: [String: Any]
-    /// OpenCode 代理「通用配置」中显式选择的默认节点（顶层 model 指向它）。
-    /// nil 表示未显式选择，重写受管配置时回退到第一个激活节点。
-    var openCodeDefaultNodeId: String?
 
-    init(enabled: Bool, settings: [String: Any], openCodeDefaultNodeId: String? = nil) {
+    init(enabled: Bool, settings: [String: Any]) {
         self.enabled = enabled
         self.settings = settings
-        self.openCodeDefaultNodeId = openCodeDefaultNodeId
     }
 
     static let empty = GlobalConfig(enabled: false, settings: [:])
@@ -44,13 +40,10 @@ struct GlobalConfig {
     // MARK: - Serialize / Deserialize
 
     func toFileData() throws -> Data {
-        var root: [String: Any] = [
+        let root: [String: Any] = [
             "enabled": enabled,
             "settings": settings,
         ]
-        if let nodeId = openCodeDefaultNodeId {
-            root["openCodeDefaultNodeId"] = nodeId
-        }
         return try JSONSerialization.data(
             withJSONObject: root,
             options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
@@ -63,7 +56,6 @@ struct GlobalConfig {
         }
         let enabled = root["enabled"] as? Bool ?? false
         let settings = root["settings"] as? [String: Any] ?? [:]
-        let openCodeDefaultNodeId = root["openCodeDefaultNodeId"] as? String
-        return GlobalConfig(enabled: enabled, settings: settings, openCodeDefaultNodeId: openCodeDefaultNodeId)
+        return GlobalConfig(enabled: enabled, settings: settings)
     }
 }

--- a/AIUsage/Models/OpenCodeNode.swift
+++ b/AIUsage/Models/OpenCodeNode.swift
@@ -70,6 +70,10 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
     /// 每模型输入/输出模态（空 = 不写 modalities，由 OpenCode 取模型默认）。
     var inputModalities: [OpenCodeModality]
     var outputModalities: [OpenCodeModality]
+    /// 每模型追加的任意 key-value 参数（值存字符串，生成时智能解析为 JSON 标量/对象/数组）。
+    /// key 支持点路径（如 "limit.context"）或顶级键（如 "temperature"）；生成 opencode.json 时
+    /// 按路径合并到该模型配置对象，覆盖节点级默认（issue #69）。空 = 不追加。
+    var extraParameters: [String: String]
 
     init(
         id: String,
@@ -79,7 +83,8 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         priceCacheWritePerMillion: Double = 0,
         pricingSource: ProxyConfiguration.ModelPricing.Source? = nil,
         inputModalities: [OpenCodeModality] = [],
-        outputModalities: [OpenCodeModality] = []
+        outputModalities: [OpenCodeModality] = [],
+        extraParameters: [String: String] = [:]
     ) {
         self.id = id
         self.priceInputPerMillion = priceInputPerMillion
@@ -89,6 +94,7 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         self.pricingSource = pricingSource
         self.inputModalities = inputModalities
         self.outputModalities = outputModalities
+        self.extraParameters = extraParameters
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -100,9 +106,10 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         case pricingSource
         case inputModalities
         case outputModalities
+        case extraParameters
     }
 
-    // 自定义解码：modalities 为后加字段，旧档案缺省 → 空数组，保证既有节点平滑升级。
+    // 自定义解码：modalities / extraParameters 为后加字段，旧档案缺省 → 空，保证既有节点平滑升级。
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(String.self, forKey: .id)
@@ -116,6 +123,7 @@ struct OpenCodeModelEntry: Codable, Equatable, Identifiable {
         )
         inputModalities = try c.decodeIfPresent([OpenCodeModality].self, forKey: .inputModalities) ?? []
         outputModalities = try c.decodeIfPresent([OpenCodeModality].self, forKey: .outputModalities) ?? []
+        extraParameters = try c.decodeIfPresent([String: String].self, forKey: .extraParameters) ?? [:]
     }
 
     var hasPricing: Bool {

--- a/AIUsage/Models/ProxyConfiguration.swift
+++ b/AIUsage/Models/ProxyConfiguration.swift
@@ -228,10 +228,26 @@ struct ProxyConfiguration: Codable, Identifiable, Equatable {
     struct MappedModel: Codable, Equatable {
         var name: String
         var pricing: ModelPricing
+        /// 每模型追加的任意 key-value 参数（生成 opencode.json 时合并到该模型配置，覆盖节点级默认）。
+        /// 值存字符串、生成时智能解析；与 OpenCodeModelEntry.extraParameters 同构（issue #69）。
+        var extraParameters: [String: String]
 
-        init(name: String, pricing: ModelPricing = .zero) {
+        init(name: String, pricing: ModelPricing = .zero, extraParameters: [String: String] = [:]) {
             self.name = name
             self.pricing = pricing
+            self.extraParameters = extraParameters
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name, pricing, extraParameters
+        }
+
+        // 自定义解码：extraParameters 为后加字段，旧档案缺省 → 空字典，保证既有 provider 平滑升级。
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            name = try c.decode(String.self, forKey: .name)
+            pricing = try c.decode(ModelPricing.self, forKey: .pricing)
+            extraParameters = try c.decodeIfPresent([String: String].self, forKey: .extraParameters) ?? [:]
         }
     }
 

--- a/AIUsage/ViewModels/APIProviderDistributor.swift
+++ b/AIUsage/ViewModels/APIProviderDistributor.swift
@@ -420,7 +420,8 @@ final class APIProviderDistributor {
                 priceOutputPerMillion: m.pricing.outputPerMillionUSD,
                 priceCacheReadPerMillion: m.pricing.cacheReadPerMillionUSD,
                 priceCacheWritePerMillion: m.pricing.cacheCreatePerMillionUSD,
-                pricingSource: m.pricing.source
+                pricingSource: m.pricing.source,
+                extraParameters: m.extraParameters
             )
         }
     }

--- a/AIUsage/ViewModels/CallAnalyticsStore.swift
+++ b/AIUsage/ViewModels/CallAnalyticsStore.swift
@@ -16,9 +16,6 @@ final class CallAnalyticsStore: ObservableObject {
 
     private let engine = CallAnalyticsEngine.shared
     private let log = Logger(subsystem: "com.aiusage.desktop", category: "CallAnalytics")
-    /// 本会话是否已至少刷新过一次（区别于「仅加载了磁盘缓存」）。
-    private var hasRefreshedThisSession = false
-
     private static let cacheSchemaVersion = CallAnalyticsSnapshot.currentSchemaVersion
 
     init() {
@@ -26,14 +23,7 @@ final class CallAnalyticsStore: ObservableObject {
         Self.pruneStaleCaches()
     }
 
-    /// 首次进入或时间范围变化时刷新；否则沿用当前快照。
-    /// `rangeKey` 为该范围的稳定标识（自定义区间含起止日期），用于判断快照是否过期。
-    func refreshIfNeeded(rangeKey: String, cutoff: Date?, end: Date?) async {
-        if hasRefreshedThisSession, snapshot.rangeKey == rangeKey { return }
-        await refresh(rangeKey: rangeKey, cutoff: cutoff, end: end)
-    }
-
-    /// 强制重新解析并刷新（手动刷新按钮 / 时间范围切换）。
+    /// 重新解析并刷新（视图出现 / 手动刷新按钮 / 时间范围切换）。
     func refresh(rangeKey: String, cutoff: Date?, end: Date?) async {
         guard !isRefreshing else { return }
         isRefreshing = true
@@ -41,7 +31,6 @@ final class CallAnalyticsStore: ObservableObject {
 
         let result = await engine.computeSnapshot(rangeKey: rangeKey, cutoff: cutoff, end: end)
         snapshot = result
-        hasRefreshedThisSession = true
         Self.saveCache(result)
         log.debug("Call analytics refreshed: \(result.entries.count, privacy: .public) entries, range \(rangeKey, privacy: .public)")
     }

--- a/AIUsage/ViewModels/GlobalProxyManager.swift
+++ b/AIUsage/ViewModels/GlobalProxyManager.swift
@@ -681,7 +681,10 @@ final class GlobalProxyManager: ObservableObject {
             if !wasCancelled, previousConfig.isEnabled == false { runtime.stop() }
             try? adapter.restoreCLIConfig()
             if !activePerNodeIds.isEmpty {
-                await adapter.activatePerNode(activePerNodeIds)
+                let restored = await adapter.activatePerNode(activePerNodeIds)
+                if !restored {
+                    globalProxyManagerLog.error("Failed to restore per-node routes after Gateway rollback (\(self.track.rawValue, privacy: .public))")
+                }
             }
             // Cancellation is an internal hand-off, not a user-facing failure,
             // but it still needs the same direct-route rollback as any error.

--- a/AIUsage/ViewModels/GlobalProxyManager.swift
+++ b/AIUsage/ViewModels/GlobalProxyManager.swift
@@ -517,11 +517,11 @@ final class GlobalProxyManager: ObservableObject {
         }
         let previousConfig = config
 
-        // 与每节点激活互斥：接管 CLI 配置前先停掉本轨当前激活的节点（干净交接）。
-        let activePerNode = adapter.currentPerNodeActiveId()
-        if let activePerNode {
-            await adapter.deactivatePerNode(activePerNode)
-            guard adapter.currentPerNodeActiveId() != activePerNode else {
+        // 与每节点激活互斥：接管 CLI 配置前先停掉本轨当前激活的所有节点（干净交接）。
+        let activePerNodeIds = adapter.currentPerNodeActiveIds()
+        if !activePerNodeIds.isEmpty {
+            await adapter.deactivatePerNode(activePerNodeIds)
+            guard adapter.currentPerNodeActiveIds().isEmpty else {
                 operationError = AppSettings.shared.t(
                     "Could not release the previous product route. Try again before starting the Gateway.",
                     "无法释放之前的应用路由，请重试后再启动 Gateway。"
@@ -596,8 +596,8 @@ final class GlobalProxyManager: ObservableObject {
             }
             if !wasCancelled, previousConfig.isEnabled == false { runtime.stop() }
             try? adapter.restoreCLIConfig()
-            if let activePerNode {
-                await adapter.activatePerNode(activePerNode)
+            if !activePerNodeIds.isEmpty {
+                await adapter.activatePerNode(activePerNodeIds)
             }
             // Cancellation is an internal hand-off, not a user-facing failure,
             // but it still needs the same direct-route rollback as any error.

--- a/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
+++ b/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
@@ -515,12 +515,7 @@ struct OpenCodeGlobalProxyAdapter: GlobalProxyTrackAdapter {
     }
 
     func deactivatePerNode(_ ids: [String]) async {
-        let store = OpenCodeNodeStore.shared
-        for id in ids {
-            if let node = store.nodes.first(where: { $0.id == id }) {
-                try? store.deactivate(node)
-            }
-        }
+        try? OpenCodeNodeStore.shared.deactivate(ids)
     }
 
     func activatePerNode(_ ids: [String]) async {

--- a/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
+++ b/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
@@ -44,11 +44,11 @@ protocol GlobalProxyTrackAdapter {
     /// 自己的 durable takeover session 做 force restore。
     func restoreCLIConfigDiscardingExternalChanges() throws
 
-    /// 本轨「每节点激活」当前激活 id（启用全局前先停掉它，干净交接）。
-    func currentPerNodeActiveId() -> String?
-    func deactivatePerNode(_ id: String) async
+    /// 本轨「每节点激活」当前激活 id 列表（启用全局前先停掉，干净交接）。
+    func currentPerNodeActiveIds() -> [String]
+    func deactivatePerNode(_ ids: [String]) async
     /// Gateway 接管失败时恢复刚才停用的每节点路由。
-    func activatePerNode(_ id: String) async
+    func activatePerNode(_ ids: [String]) async
 }
 
 extension GlobalProxyTrackAdapter {
@@ -114,16 +114,21 @@ struct CodexGlobalProxyAdapter: GlobalProxyTrackAdapter {
         try CodexConfigManager.shared.restore()
     }
 
-    func currentPerNodeActiveId() -> String? {
-        ProxyViewModel.shared.activatedId(isCodex: true)
+    func currentPerNodeActiveIds() -> [String] {
+        guard let id = ProxyViewModel.shared.activatedId(isCodex: true) else { return [] }
+        return [id]
     }
 
-    func deactivatePerNode(_ id: String) async {
-        await ProxyViewModel.shared.deactivateConfiguration(id)
+    func deactivatePerNode(_ ids: [String]) async {
+        for id in ids {
+            await ProxyViewModel.shared.deactivateConfiguration(id)
+        }
     }
 
-    func activatePerNode(_ id: String) async {
-        await ProxyViewModel.shared.activateConfiguration(id)
+    func activatePerNode(_ ids: [String]) async {
+        for id in ids {
+            await ProxyViewModel.shared.activateConfiguration(id)
+        }
     }
 }
 
@@ -313,18 +318,23 @@ struct ClaudeGlobalProxyAdapter: GlobalProxyTrackAdapter {
         try ClaudeSettingsManager.shared.clearEnv()
     }
 
-    func currentPerNodeActiveId() -> String? {
-        track == .claude ? ProxyViewModel.shared.activatedId(isCodex: false) : nil
+    func currentPerNodeActiveIds() -> [String] {
+        guard track == .claude, let id = ProxyViewModel.shared.activatedId(isCodex: false) else { return [] }
+        return [id]
     }
 
-    func deactivatePerNode(_ id: String) async {
+    func deactivatePerNode(_ ids: [String]) async {
         guard track == .claude else { return }
-        await ProxyViewModel.shared.deactivateConfiguration(id)
+        for id in ids {
+            await ProxyViewModel.shared.deactivateConfiguration(id)
+        }
     }
 
-    func activatePerNode(_ id: String) async {
+    func activatePerNode(_ ids: [String]) async {
         guard track == .claude else { return }
-        await ProxyViewModel.shared.activateConfiguration(id)
+        for id in ids {
+            await ProxyViewModel.shared.activateConfiguration(id)
+        }
     }
 }
 

--- a/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
+++ b/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
@@ -51,8 +51,8 @@ protocol GlobalProxyTrackAdapter {
     /// 本轨「每节点激活」当前激活 id 列表（启用全局前先停掉，干净交接）。
     func currentPerNodeActiveIds() -> [String]
     func deactivatePerNode(_ ids: [String]) async
-    /// Gateway 接管失败时恢复刚才停用的每节点路由。
-    func activatePerNode(_ ids: [String]) async
+    /// Gateway 接管失败时恢复刚才停用的每节点路由；返回 false 表示恢复失败（存在未恢复的节点）。
+    func activatePerNode(_ ids: [String]) async -> Bool
 }
 
 extension GlobalProxyTrackAdapter {
@@ -155,10 +155,11 @@ struct CodexGlobalProxyAdapter: GlobalProxyTrackAdapter {
         }
     }
 
-    func activatePerNode(_ ids: [String]) async {
+    func activatePerNode(_ ids: [String]) async -> Bool {
         for id in ids {
             await ProxyViewModel.shared.activateConfiguration(id)
         }
+        return true
     }
 }
 
@@ -360,11 +361,12 @@ struct ClaudeGlobalProxyAdapter: GlobalProxyTrackAdapter {
         }
     }
 
-    func activatePerNode(_ ids: [String]) async {
-        guard track == .claude else { return }
+    func activatePerNode(_ ids: [String]) async -> Bool {
+        guard track == .claude else { return false }
         for id in ids {
             await ProxyViewModel.shared.activateConfiguration(id)
         }
+        return true
     }
 }
 
@@ -518,10 +520,14 @@ struct OpenCodeGlobalProxyAdapter: GlobalProxyTrackAdapter {
         try? OpenCodeNodeStore.shared.deactivate(ids)
     }
 
-    func activatePerNode(_ ids: [String]) async {
-        for id in ids {
-            guard let node = node(id) else { continue }
-            try? await OpenCodeNodeStore.shared.activate(node)
+    func activatePerNode(_ ids: [String]) async -> Bool {
+        let nodes = ids.compactMap { node($0) }
+        guard nodes.count == ids.count else { return false }
+        do {
+            try await OpenCodeNodeStore.shared.activate(nodes)
+            return true
+        } catch {
+            return false
         }
     }
 }

--- a/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
+++ b/AIUsage/ViewModels/GlobalProxyTrackAdapters.swift
@@ -447,16 +447,23 @@ struct OpenCodeGlobalProxyAdapter: GlobalProxyTrackAdapter {
         try OpenCodeConfigManager.shared.restoreDiscardingExternalChanges()
     }
 
-    func currentPerNodeActiveId() -> String? {
-        OpenCodeNodeStore.shared.activeNodeId
+    func currentPerNodeActiveIds() -> [String] {
+        OpenCodeNodeStore.shared.activeNodeIds
     }
 
-    func deactivatePerNode(_ id: String) async {
-        try? OpenCodeNodeStore.shared.deactivate()
+    func deactivatePerNode(_ ids: [String]) async {
+        let store = OpenCodeNodeStore.shared
+        for id in ids {
+            if let node = store.nodes.first(where: { $0.id == id }) {
+                try? store.deactivate(node)
+            }
+        }
     }
 
-    func activatePerNode(_ id: String) async {
-        guard let node = node(id) else { return }
-        try? await OpenCodeNodeStore.shared.activate(node)
+    func activatePerNode(_ ids: [String]) async {
+        for id in ids {
+            guard let node = node(id) else { continue }
+            try? await OpenCodeNodeStore.shared.activate(node)
+        }
     }
 }

--- a/AIUsage/ViewModels/OpenCodeConfigManager.swift
+++ b/AIUsage/ViewModels/OpenCodeConfigManager.swift
@@ -653,7 +653,7 @@ final class OpenCodeConfigManager {
             // 每模型追加参数（issue #69）：在节点级默认 limit/options 写入之后按点路径合并，
             // 覆盖节点级默认值，实现 per-model 独立配置。
             if !model.extraParameters.isEmpty {
-                entry = Self.applyExtraParameters(model.extraParameters, to: entry)
+                entry = ExtraParametersApplier.applyExtraParameters(model.extraParameters, to: entry)
             }
             modelsBlock[model.id] = entry
         }
@@ -714,59 +714,6 @@ final class OpenCodeConfigManager {
         )
         root["model"] = "\(node.managedProviderId)/\(defaultModel)"
         return root
-    }
-
-    /// 把每模型追加参数按点路径合并进模型 entry，覆盖节点级默认（issue #69）。
-    /// 值存字符串，此处智能解析为 JSON 标量/对象/数组后写入。
-    nonisolated static func applyExtraParameters(
-        _ parameters: [String: String],
-        to entry: [String: Any]
-    ) -> [String: Any] {
-        var result = entry
-        for (key, rawValue) in parameters {
-            guard let value = parseParameterValue(rawValue) else { continue }
-            setNestedValue(value, atPath: key, in: &result)
-        }
-        return result
-    }
-
-    /// 把字符串值解析为 JSON 值：整数/浮点/布尔/null 字面量、`{...}`/`[...]` 走 JSON 解析，
-    /// 其余原样保留为字符串。
-    nonisolated static func parseParameterValue(_ rawValue: String) -> Any? {
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return nil }
-        if let intValue = Int(trimmed) { return intValue }
-        if let doubleValue = Double(trimmed), trimmed.contains(".") { return doubleValue }
-        switch trimmed.lowercased() {
-        case "true": return true
-        case "false": return false
-        case "null", "nil": return NSNull()
-        default: break
-        }
-        if trimmed.hasPrefix("{") || trimmed.hasPrefix("[") {
-            if let data = trimmed.data(using: .utf8),
-               let object = try? JSONSerialization.jsonObject(with: data) {
-                return object
-            }
-        }
-        return rawValue
-    }
-
-    /// 按点路径（如 "limit.context"）把值写入嵌套字典；多段 key 逐层创建中间字典。
-    nonisolated static func setNestedValue(
-        _ value: Any,
-        atPath path: String,
-        in dict: inout [String: Any]
-    ) {
-        let components = path.split(separator: ".").map(String.init).filter { !$0.isEmpty }
-        guard let first = components.first else { return }
-        if components.count == 1 {
-            dict[first] = value
-            return
-        }
-        var child = dict[first] as? [String: Any] ?? [:]
-        setNestedValue(value, atPath: components.dropFirst().joined(separator: "."), in: &child)
-        dict[first] = child
     }
 
     /// 当前全局层的合并结果。接管目标使用备份中的原始内容，其他低优先级层按

--- a/AIUsage/ViewModels/OpenCodeConfigManager.swift
+++ b/AIUsage/ViewModels/OpenCodeConfigManager.swift
@@ -620,6 +620,11 @@ final class OpenCodeConfigManager {
                 }
                 entry["cost"] = costBlock
             }
+            // 每模型追加参数（issue #69）：在节点级默认 limit/options 写入之后按点路径合并，
+            // 覆盖节点级默认值，实现 per-model 独立配置。
+            if !model.extraParameters.isEmpty {
+                entry = Self.applyExtraParameters(model.extraParameters, to: entry)
+            }
             modelsBlock[model.id] = entry
         }
 
@@ -662,6 +667,59 @@ final class OpenCodeConfigManager {
         root["provider"] = provider
         root["model"] = "\(managedId)/\(defaultModel)"
         return root
+    }
+
+    /// 把每模型追加参数按点路径合并进模型 entry，覆盖节点级默认（issue #69）。
+    /// 值存字符串，此处智能解析为 JSON 标量/对象/数组后写入。
+    nonisolated static func applyExtraParameters(
+        _ parameters: [String: String],
+        to entry: [String: Any]
+    ) -> [String: Any] {
+        var result = entry
+        for (key, rawValue) in parameters {
+            guard let value = parseParameterValue(rawValue) else { continue }
+            setNestedValue(value, atPath: key, in: &result)
+        }
+        return result
+    }
+
+    /// 把字符串值解析为 JSON 值：整数/浮点/布尔/null 字面量、`{...}`/`[...]` 走 JSON 解析，
+    /// 其余原样保留为字符串。
+    nonisolated static func parseParameterValue(_ rawValue: String) -> Any? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        if let intValue = Int(trimmed) { return intValue }
+        if let doubleValue = Double(trimmed), trimmed.contains(".") { return doubleValue }
+        switch trimmed.lowercased() {
+        case "true": return true
+        case "false": return false
+        case "null", "nil": return NSNull()
+        default: break
+        }
+        if trimmed.hasPrefix("{") || trimmed.hasPrefix("[") {
+            if let data = trimmed.data(using: .utf8),
+               let object = try? JSONSerialization.jsonObject(with: data) {
+                return object
+            }
+        }
+        return rawValue
+    }
+
+    /// 按点路径（如 "limit.context"）把值写入嵌套字典；多段 key 逐层创建中间字典。
+    nonisolated static func setNestedValue(
+        _ value: Any,
+        atPath path: String,
+        in dict: inout [String: Any]
+    ) {
+        let components = path.split(separator: ".").map(String.init).filter { !$0.isEmpty }
+        guard let first = components.first else { return }
+        if components.count == 1 {
+            dict[first] = value
+            return
+        }
+        var child = dict[first] as? [String: Any] ?? [:]
+        setNestedValue(value, atPath: components.dropFirst().joined(separator: "."), in: &child)
+        dict[first] = child
     }
 
     /// 当前全局层的合并结果。接管目标使用备份中的原始内容，其他低优先级层按

--- a/AIUsage/ViewModels/OpenCodeConfigManager.swift
+++ b/AIUsage/ViewModels/OpenCodeConfigManager.swift
@@ -289,34 +289,58 @@ final class OpenCodeConfigManager {
     /// - Parameter commonSettings: 通用配置片段（按节点合并策略由调用方决定传入与否）。
     ///   合并顺序：用户原文 ← 通用配置 ← 受管块（受管键始终最终生效）。
     func activate(node: OpenCodeNode, baseURLOverride: String? = nil, commonSettings: [String: Any]? = nil) throws {
-        guard let defaultModel = node.effectiveDefaultModel, node.isComplete else {
-            throw OpenCodeConfigError.nodeIncomplete
+        try activate(nodes: [node], defaultNodeId: node.id) { _ in commonSettings }
+    }
+
+    /// 多节点激活（issue #66）：把多个节点的受管 provider 块同时注入 opencode 配置，顶层 model
+    /// 指向 defaultNodeId（最近激活的节点）。激活/停用单节点后都由调用方全量重写一次。
+    /// - Parameter commonSettingsFor: 每节点的通用配置片段（按节点合并策略，nil 表示不合并）。
+    func activate(
+        nodes: [OpenCodeNode],
+        defaultNodeId: String,
+        commonSettingsFor: (OpenCodeNode) -> [String: Any]?
+    ) throws {
+        let defaultNode = nodes.first(where: { $0.id == defaultNodeId }) ?? nodes.last
+        guard let defaultNode else { return }
+        for node in nodes {
+            guard node.isComplete, node.effectiveDefaultModel != nil else {
+                throw OpenCodeConfigError.nodeIncomplete
+            }
         }
         let hadSession = session != nil
         do {
             let pristine = try establishBackupAndLoadPristine()
             try withManagedFilesTransaction {
-                // 密钥与配置属于同一次事务。代理模式下清掉残留直连凭据，避免 auth.json 覆盖 client key。
-                let directAPIKey = baseURLOverride == nil ? node.apiKey.nilIfBlank : nil
-                let credentials = directAPIKey.map { [node.managedProviderId: $0] } ?? [:]
+                // 密钥与配置属于同一次事务。所有直连节点的 key 写入 auth.json（多 key 字典），
+                // 代理节点的真实 key 留在代理进程、client key 内联进各自受管块。
+                var credentials: [String: String] = [:]
+                for node in nodes where !node.proxyEnabled {
+                    if let key = node.apiKey.nilIfBlank {
+                        credentials[node.managedProviderId] = key
+                    }
+                }
                 let credentialsStored = authStore.syncManagedCredentials(credentials)
                 let keyPlacement: ManagedAPIKeyPlacement = credentialsStored ? .externalAuthFile : .inlineOptions
                 if !credentialsStored {
                     openCodeConfigLog.error("auth.json write failed, falling back to inline apiKey in opencode config")
                 }
 
-                let root = injectManagedEntries(
-                    into: mergedBase(pristine: pristine, commonSettings: commonSettings),
-                    node: node,
-                    defaultModel: defaultModel,
-                    baseURLOverride: baseURLOverride,
-                    keyPlacement: keyPlacement
-                )
+                // 通用配置只合并一次（按默认节点策略），provider 块每个节点注入一个。
+                var root = mergedBase(pristine: pristine, commonSettings: commonSettingsFor(defaultNode))
+                for node in nodes {
+                    root = injectNodeBlock(
+                        into: root,
+                        node: node,
+                        baseURLOverride: node.proxyEnabled ? node.proxyLocalBaseURL : nil,
+                        keyPlacement: keyPlacement
+                    )
+                }
+                root["model"] = "\(defaultNode.managedProviderId)/\(defaultNode.effectiveDefaultModel!)"
 
                 try writeManagedRoot(root)
                 try verifyEffectiveManagedProjection(target: root)
                 try recordManagedHash()
-                openCodeConfigLog.info("opencode config managed provider injected (provider=\(node.managedProviderId, privacy: .public), models=\(node.models.count), jsonc=\(self.usesJSONC, privacy: .public), keyInAuthFile=\(keyPlacement == .externalAuthFile, privacy: .public))")
+                openCodeConfigLog.info("opencode config managed providers injected (nodes=\(nodes.count, privacy: .public), default=\(defaultNode.managedProviderId, privacy: .public), jsonc=\(self.usesJSONC, privacy: .public), keyInAuthFile=\(keyPlacement == .externalAuthFile, privacy: .public))")
             }
         } catch {
             if !hadSession { discardSessionFiles() }
@@ -640,13 +664,12 @@ final class OpenCodeConfigManager {
         ]
     }
 
-    /// 把受管块注入干净原文：provider[managedId] + 顶层 model 指向（含 $schema 补齐）。
-    private func injectManagedEntries(
+    /// 注入单个节点的 provider 块（只动 provider[managedId] + 补齐 $schema，不设顶层 model）。
+    private func injectNodeBlock(
         into cleanRoot: [String: Any],
         node: OpenCodeNode,
-        defaultModel: String,
         baseURLOverride: String?,
-        keyPlacement: ManagedAPIKeyPlacement = .externalAuthFile
+        keyPlacement: ManagedAPIKeyPlacement
     ) -> [String: Any] {
         var root = cleanRoot
         if root["$schema"] == nil {
@@ -660,7 +683,25 @@ final class OpenCodeConfigManager {
             keyPlacement: keyPlacement
         )
         root["provider"] = provider
-        root["model"] = "\(managedId)/\(defaultModel)"
+        return root
+    }
+
+    /// 把受管块注入干净原文：provider[managedId] + 顶层 model 指向（含 $schema 补齐）。
+    /// 单节点预览/启动命令导出仍用此入口；多节点激活走 injectNodeBlock 逐块注入。
+    private func injectManagedEntries(
+        into cleanRoot: [String: Any],
+        node: OpenCodeNode,
+        defaultModel: String,
+        baseURLOverride: String?,
+        keyPlacement: ManagedAPIKeyPlacement = .externalAuthFile
+    ) -> [String: Any] {
+        var root = injectNodeBlock(
+            into: cleanRoot,
+            node: node,
+            baseURLOverride: baseURLOverride,
+            keyPlacement: keyPlacement
+        )
+        root["model"] = "\(node.managedProviderId)/\(defaultModel)"
         return root
     }
 

--- a/AIUsage/ViewModels/OpenCodeConfigManager.swift
+++ b/AIUsage/ViewModels/OpenCodeConfigManager.swift
@@ -460,7 +460,13 @@ final class OpenCodeConfigManager {
             let current = try readObject(atPath: targetPath) ?? [:]
             try fileManager.createDirectory(atPath: backupRoot, withIntermediateDirectories: true)
             if managedKeysPresent(in: current) {
-                try writeObject(stripManagedEntries(from: current), toPath: path, restrictPermissions: true)
+                let stripped = stripManagedEntries(from: current)
+                let rawText = String(data: data, encoding: .utf8) ?? ""
+                if let patched = JSONCEditor.merge(baseText: rawText, target: stripped) {
+                    try writeText(patched, toPath: path, restrictPermissions: true)
+                } else {
+                    try writeObject(stripped, toPath: path, restrictPermissions: true)
+                }
             } else {
                 try copyFileVerbatim(from: targetPath, to: path)
             }

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -47,6 +47,9 @@ final class OpenCodeNodeStore: ObservableObject {
     /// 通用配置片段（与 Claude 页同构）：激活时按节点合并策略深合并进受管层，
     /// 受管块与用户原文之间的中间层。持久化于 ~/.config/aiusage/opencode-global-config.json。
     @Published var globalConfig: GlobalConfig = .empty
+    /// 多节点同时激活时顶层 model 指向的「默认模型节点」（独立于通用配置）。
+    /// nil 表示未显式选择，重写受管配置时回退到第一个激活节点。
+    @Published private(set) var openCodeDefaultNodeId: String?
 
     private let configManager = OpenCodeConfigManager.shared
     private let proxyRuntime = OpenCodeProxyRuntime.shared
@@ -58,6 +61,7 @@ final class OpenCodeNodeStore: ObservableObject {
         var activeNodeId: String?
         var activeNodeIds: [String]?
         var proxyOnlyNodeIds: [String]?
+        var openCodeDefaultNodeId: String?
     }
 
     private static let storeVersion = 1
@@ -215,6 +219,21 @@ final class OpenCodeNodeStore: ObservableObject {
         }
     }
 
+    /// 设置「默认模型节点」并立即重写受管配置（顶层 model 指向它）。
+    /// 传 nil 回到「自动（第一个激活节点）」。
+    func setOpenCodeDefaultNodeId(_ id: String?) {
+        guard openCodeDefaultNodeId != id else { return }
+        openCodeDefaultNodeId = id
+        save()
+        if !activeNodeIds.isEmpty {
+            do {
+                try rewriteManagedConfig()
+            } catch {
+                openCodeStoreLog.error("Failed to reapply default model node: \(String(describing: error), privacy: .public)")
+            }
+        }
+    }
+
     /// Force SwiftUI to refresh file-resolution labels after an external file edit.
     func refreshConfigContext() {
         objectWillChange.send()
@@ -325,7 +344,7 @@ final class OpenCodeNodeStore: ObservableObject {
         objectWillChange.send()
     }
 
-    /// 顶层 model 指向显式选择的默认节点（未选择或失效回退第一个激活节点）；`ids` 传候选集合
+    /// 顶层 model 指向显式选择的「默认模型节点」（未选择或失效回退第一个激活节点）；`ids` 传候选集合
     /// （停用流程在提交 activeNodeIds 前调用，避免读到未提交状态），nil 用当前 activeNodeIds。
     private func rewriteManagedConfig(using ids: [String]? = nil) throws {
         let targetIds = ids ?? activeNodeIds
@@ -335,7 +354,7 @@ final class OpenCodeNodeStore: ObservableObject {
             return
         }
         let defaultNodeId: String
-        if let chosen = globalConfig.openCodeDefaultNodeId, targetIds.contains(chosen) {
+        if let chosen = openCodeDefaultNodeId, targetIds.contains(chosen) {
             defaultNodeId = chosen
         } else {
             defaultNodeId = activeNodes[0].id
@@ -541,6 +560,7 @@ final class OpenCodeNodeStore: ObservableObject {
             nodes = file.nodes
             activeNodeIds = file.activeNodeIds ?? (file.activeNodeId.map { [$0] } ?? [])
             proxyOnlyNodeIds = Set(file.proxyOnlyNodeIds ?? [])
+            openCodeDefaultNodeId = file.openCodeDefaultNodeId
             sortNodes()
             backfillProviderSlugs()
         } catch {
@@ -566,7 +586,8 @@ final class OpenCodeNodeStore: ObservableObject {
             nodes: nodes,
             activeNodeId: activeNodeIds.last,
             activeNodeIds: activeNodeIds.isEmpty ? nil : activeNodeIds,
-            proxyOnlyNodeIds: proxyOnlyNodeIds.isEmpty ? nil : Array(proxyOnlyNodeIds).sorted()
+            proxyOnlyNodeIds: proxyOnlyNodeIds.isEmpty ? nil : Array(proxyOnlyNodeIds).sorted(),
+            openCodeDefaultNodeId: openCodeDefaultNodeId
         )
         do {
             let dir = (Self.storePath as NSString).deletingLastPathComponent

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -48,7 +48,7 @@ final class OpenCodeNodeStore: ObservableObject {
     /// 受管块与用户原文之间的中间层。持久化于 ~/.config/aiusage/opencode-global-config.json。
     @Published var globalConfig: GlobalConfig = .empty
     /// 多节点同时激活时顶层 model 指向的「默认模型节点」（独立于通用配置）。
-    /// nil 表示未显式选择，重写受管配置时回退到第一个激活节点。
+    /// nil 表示未显式选择，重写受管配置时回退到节点列表中排第一个的激活节点。
     @Published private(set) var openCodeDefaultNodeId: String?
 
     private let configManager = OpenCodeConfigManager.shared
@@ -254,6 +254,7 @@ final class OpenCodeNodeStore: ObservableObject {
             proxyRuntime.stop(nodeId: node.id)
         }
         activeNodeIds.removeAll()
+        openCodeDefaultNodeId = nil
         save()
         objectWillChange.send()
     }
@@ -324,6 +325,9 @@ final class OpenCodeNodeStore: ObservableObject {
         }
         let removedIds = Set(activeNodeIds).subtracting(remainingIds)
         activeNodeIds = remainingIds
+        if let chosen = openCodeDefaultNodeId, removedIds.contains(chosen) {
+            openCodeDefaultNodeId = nil
+        }
         for id in removedIds {
             guard let node = nodes.first(where: { $0.id == id }),
                   node.proxyEnabled, !proxyOnlyNodeIds.contains(id) else { continue }
@@ -340,6 +344,7 @@ final class OpenCodeNodeStore: ObservableObject {
             proxyRuntime.stop(nodeId: node.id)
         }
         activeNodeIds.removeAll()
+        openCodeDefaultNodeId = nil
         save()
         objectWillChange.send()
     }
@@ -357,7 +362,8 @@ final class OpenCodeNodeStore: ObservableObject {
         if let chosen = openCodeDefaultNodeId, targetIds.contains(chosen) {
             defaultNodeId = chosen
         } else {
-            defaultNodeId = activeNodes[0].id
+            // 回退到「自动」：节点列表中排第一个且处于激活状态的节点。
+            defaultNodeId = nodes.first(where: { targetIds.contains($0.id) })?.id ?? activeNodes[0].id
         }
         try configManager.activate(
             nodes: activeNodes,

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -220,18 +220,21 @@ final class OpenCodeNodeStore: ObservableObject {
     }
 
     /// 设置「默认模型节点」并立即重写受管配置（顶层 model 指向它）。
-    /// 传 nil 回到「自动（第一个激活节点）」。
+    /// 传 nil 回到「自动（第一个激活节点）」。先完成配置写入成功后再提交新选择，
+    /// 写入失败时保持原默认节点不变。
     func setOpenCodeDefaultNodeId(_ id: String?) {
         guard openCodeDefaultNodeId != id else { return }
-        openCodeDefaultNodeId = id
-        save()
         if !activeNodeIds.isEmpty {
+            let resolved = id ?? nodes.first(where: { activeNodeIds.contains($0.id) })?.id
             do {
-                try rewriteManagedConfig()
+                try rewriteManagedConfig(defaultNodeIdOverride: resolved)
             } catch {
                 openCodeStoreLog.error("Failed to reapply default model node: \(String(describing: error), privacy: .public)")
+                return
             }
         }
+        openCodeDefaultNodeId = id
+        save()
     }
 
     /// Force SwiftUI to refresh file-resolution labels after an external file edit.
@@ -306,6 +309,56 @@ final class OpenCodeNodeStore: ObservableObject {
         objectWillChange.send()
     }
 
+    /// 批量激活多个节点（一次事务，用于恢复刚停用的每节点路由 / 批量切换）：
+    /// 先启动全部代理进程并升级仅代理标记，再一次性重写受管配置，最后提交激活集合；
+    /// 任一步失败时回收已启动代理、恢复仅代理标记，激活集合保持原值（不留部分激活）。
+    func activate(_ nodes: [OpenCodeNode]) async throws {
+        guard !nodes.isEmpty else { return }
+        // 与全局统一代理互斥：全局启用时由它独占受管层，每节点激活会覆盖全局受管块。
+        if GlobalProxyManager.opencode.config.isEnabled {
+            throw OpenCodeNodeStoreError.managedByGlobalProxy
+        }
+        let newIds = nodes.map(\.id)
+        var upgradedProxyOnly: [String] = []
+        var startedProxyIds: [String] = []
+
+        do {
+            for node in nodes {
+                guard node.proxyEnabled else { continue }
+                // Codex 轨道（responses 透传）启动时强制要求 Key，缺失会让 QuotaServer
+                // 静默不挂载代理路由，请求全 404——提前拦截给出可读错误。
+                if node.protocolType == .openAIResponses, node.apiKey.nilIfBlank == nil {
+                    throw OpenCodeNodeStoreError.proxyRequiresAPIKey
+                }
+                // 该节点此前以仅代理运行：升级为激活（参数没变时进程原地复用，不闪断）。
+                if proxyOnlyNodeIds.remove(node.id) != nil {
+                    upgradedProxyOnly.append(node.id)
+                }
+                try await proxyRuntime.start(node: node)
+                startedProxyIds.append(node.id)
+            }
+            // 一次性重写受管配置；此时尚未提交激活集合，失败只需回收代理进程。
+            try rewriteManagedConfig(using: newIds)
+        } catch {
+            for id in startedProxyIds {
+                proxyRuntime.stop(nodeId: id)
+            }
+            for id in upgradedProxyOnly {
+                proxyOnlyNodeIds.insert(id)
+            }
+            throw error
+        }
+
+        activeNodeIds = newIds
+        for node in nodes {
+            if let index = self.nodes.firstIndex(where: { $0.id == node.id }) {
+                self.nodes[index].lastUsedAt = Date()
+            }
+        }
+        save()
+        objectWillChange.send()
+    }
+
     /// 停用单个节点（issue #66）：委托给批量停用，保证事务一致。
     func deactivate(_ node: OpenCodeNode) throws {
         try deactivate([node.id])
@@ -351,7 +404,7 @@ final class OpenCodeNodeStore: ObservableObject {
 
     /// 顶层 model 指向显式选择的「默认模型节点」（未选择或失效回退第一个激活节点）；`ids` 传候选集合
     /// （停用流程在提交 activeNodeIds 前调用，避免读到未提交状态），nil 用当前 activeNodeIds。
-    private func rewriteManagedConfig(using ids: [String]? = nil) throws {
+    private func rewriteManagedConfig(using ids: [String]? = nil, defaultNodeIdOverride: String? = nil) throws {
         let targetIds = ids ?? activeNodeIds
         let activeNodes = targetIds.compactMap { id in nodes.first { $0.id == id } }
         guard !activeNodes.isEmpty else {
@@ -359,7 +412,9 @@ final class OpenCodeNodeStore: ObservableObject {
             return
         }
         let defaultNodeId: String
-        if let chosen = openCodeDefaultNodeId, targetIds.contains(chosen) {
+        if let chosen = defaultNodeIdOverride, targetIds.contains(chosen) {
+            defaultNodeId = chosen
+        } else if let chosen = openCodeDefaultNodeId, targetIds.contains(chosen) {
             defaultNodeId = chosen
         } else {
             // 回退到「自动」：节点列表中排第一个且处于激活状态的节点。

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -286,17 +286,29 @@ final class OpenCodeNodeStore: ObservableObject {
         objectWillChange.send()
     }
 
-    /// 停用单个节点（issue #66）：仍有其它激活节点时重写配置，否则还原受管层。
+    /// 停用单个节点（issue #66）：委托给批量停用，保证事务一致。
     func deactivate(_ node: OpenCodeNode) throws {
-        guard activeNodeIds.contains(node.id) else { return }
-        activeNodeIds.removeAll { $0 == node.id }
-        if node.proxyEnabled, !proxyOnlyNodeIds.contains(node.id) {
-            proxyRuntime.stop(nodeId: node.id)
-        }
-        if activeNodeIds.isEmpty {
+        try deactivate([node.id])
+    }
+
+    /// 停用多个节点：一次性计算停用后集合并重写/还原配置，配置成功后再提交激活集合、
+    /// 停代理并持久化；任一步失败时原激活集合、代理进程、有效配置全部不变。
+    func deactivate(_ ids: [String]) throws {
+        let targetSet = Set(ids)
+        guard !targetSet.isEmpty else { return }
+        let remainingIds = activeNodeIds.filter { !targetSet.contains($0) }
+        guard remainingIds.count != activeNodeIds.count else { return }
+        if remainingIds.isEmpty {
             try configManager.restore()
         } else {
-            try rewriteManagedConfig()
+            try rewriteManagedConfig(using: remainingIds)
+        }
+        let removedIds = Set(activeNodeIds).subtracting(remainingIds)
+        activeNodeIds = remainingIds
+        for id in removedIds {
+            guard let node = nodes.first(where: { $0.id == id }),
+                  node.proxyEnabled, !proxyOnlyNodeIds.contains(id) else { continue }
+            proxyRuntime.stop(nodeId: id)
         }
         save()
         objectWillChange.send()
@@ -313,17 +325,24 @@ final class OpenCodeNodeStore: ObservableObject {
         objectWillChange.send()
     }
 
-    /// 全量重写受管配置：把 activeNodeIds 对应的所有节点 provider 块注入 opencode 配置，
-    /// 顶层 model 指向最近激活节点（activeNodeIds 末位）。
-    private func rewriteManagedConfig() throws {
-        let activeNodes = activeNodeIds.compactMap { id in nodes.first { $0.id == id } }
+    /// 顶层 model 指向显式选择的默认节点（未选择或失效回退第一个激活节点）；`ids` 传候选集合
+    /// （停用流程在提交 activeNodeIds 前调用，避免读到未提交状态），nil 用当前 activeNodeIds。
+    private func rewriteManagedConfig(using ids: [String]? = nil) throws {
+        let targetIds = ids ?? activeNodeIds
+        let activeNodes = targetIds.compactMap { id in nodes.first { $0.id == id } }
         guard !activeNodes.isEmpty else {
             try configManager.restore()
             return
         }
+        let defaultNodeId: String
+        if let chosen = globalConfig.openCodeDefaultNodeId, targetIds.contains(chosen) {
+            defaultNodeId = chosen
+        } else {
+            defaultNodeId = activeNodes[0].id
+        }
         try configManager.activate(
             nodes: activeNodes,
-            defaultNodeId: activeNodeIds.last ?? activeNodes[0].id
+            defaultNodeId: defaultNodeId
         ) { [weak self] node in
             self?.commonSettings(for: node)
         }
@@ -390,9 +409,10 @@ final class OpenCodeNodeStore: ObservableObject {
             let proxyActiveIds = activeNodeIds.filter { id in
                 nodes.first(where: { $0.id == id })?.proxyEnabled == true
             }
-            for id in proxyActiveIds {
-                guard let node = nodes.first(where: { $0.id == id }) else { continue }
-                do { try deactivate(node) } catch {
+            if !proxyActiveIds.isEmpty {
+                do {
+                    try deactivate(proxyActiveIds)
+                } catch {
                     openCodeStoreLog.error("Failed to deactivate OpenCode proxy node while auto-restore disabled: \(SensitiveDataRedactor.redactedMessage(for: error), privacy: .public)")
                 }
             }

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -384,10 +384,16 @@ final class OpenCodeNodeStore: ObservableObject {
     private func restoreProxyIfNeeded() {
         // 与 Claude/Codex 一致：受「启动时自动恢复代理」设置控制。关闭时不接管，
         // 并还原受管配置层（避免它仍指向不会被拉起的本地端口）。
+        // 仅代理节点依赖本地进程：进程未自动恢复时其受管块会指向不存在的端口，需停用还原；
+        // 直连节点配置持久、无需恢复，重启后应保持激活。
         guard AppSettings.shared.proxyAutoRestoreOnLaunch else {
-            if !activeNodeIds.isEmpty {
-                do { try deactivate() } catch {
-                    openCodeStoreLog.error("Failed to deactivate OpenCode node while auto-restore disabled: \(SensitiveDataRedactor.redactedMessage(for: error), privacy: .public)")
+            let proxyActiveIds = activeNodeIds.filter { id in
+                nodes.first(where: { $0.id == id })?.proxyEnabled == true
+            }
+            for id in proxyActiveIds {
+                guard let node = nodes.first(where: { $0.id == id }) else { continue }
+                do { try deactivate(node) } catch {
+                    openCodeStoreLog.error("Failed to deactivate OpenCode proxy node while auto-restore disabled: \(SensitiveDataRedactor.redactedMessage(for: error), privacy: .public)")
                 }
             }
             return

--- a/AIUsage/ViewModels/OpenCodeNodeStore.swift
+++ b/AIUsage/ViewModels/OpenCodeNodeStore.swift
@@ -5,7 +5,7 @@ import os.log
 import QuotaBackend
 
 // MARK: - OpenCode Node Store
-// OpenCode 节点的持久化与激活状态。节点列表 + activeNodeId 存为单文件
+// OpenCode 节点的持久化与激活状态。节点列表 + activeNodeIds（可多节点同时激活）存为单文件
 // ~/.config/aiusage/opencode-nodes.json（含 API Key，0600 权限）。
 // 激活/停用委托 OpenCodeConfigManager 写受管全局层；启动时与配置文件实际状态对账。
 // 代理模式节点：激活前先经 OpenCodeProxyRuntime 拉起本地透传进程，受管层指向
@@ -38,7 +38,8 @@ final class OpenCodeNodeStore: ObservableObject {
     static let shared = OpenCodeNodeStore()
 
     @Published private(set) var nodes: [OpenCodeNode] = []
-    @Published private(set) var activeNodeId: String?
+    /// 当前激活的节点 id 列表（issue #66：多节点可同时激活；末位 = 最近激活，顶层 model 指向它）。
+    @Published private(set) var activeNodeIds: [String] = []
     /// 「仅代理」运行中的节点集合（不接管全局配置，仅拉起本地透传进程暴露端口，
     /// 供启动命令等外部接入使用）。与 Claude/Codex 同语义：可多个并行（各占一端口）、
     /// 与激活互不影响；激活某节点时该节点退出仅代理（代理随激活运行）。
@@ -55,6 +56,7 @@ final class OpenCodeNodeStore: ObservableObject {
         var version: Int
         var nodes: [OpenCodeNode]
         var activeNodeId: String?
+        var activeNodeIds: [String]?
         var proxyOnlyNodeIds: [String]?
     }
 
@@ -79,9 +81,15 @@ final class OpenCodeNodeStore: ObservableObject {
 
     // MARK: - Derived State
 
+    /// 最近激活的节点（顶层 model 指向它），兼容旧 UI 显示。
     var activeNode: OpenCodeNode? {
-        guard let activeNodeId else { return nil }
-        return nodes.first { $0.id == activeNodeId }
+        guard let lastId = activeNodeIds.last else { return nil }
+        return nodes.first { $0.id == lastId }
+    }
+
+    /// 所有激活节点（按激活顺序，末位为最近）。
+    var activeNodes: [OpenCodeNode] {
+        activeNodeIds.compactMap { id in nodes.first { $0.id == id } }
     }
 
     var configPath: String { configManager.configPath }
@@ -116,7 +124,7 @@ final class OpenCodeNodeStore: ObservableObject {
         save()
 
         // 编辑当前激活节点后立即重新激活（重写受管层；代理参数未变时进程原地复用）。
-        if updated.id == activeNodeId {
+        if activeNodeIds.contains(updated.id) {
             Task { [weak self] in
                 try? await self?.activate(updated)
             }
@@ -133,9 +141,9 @@ final class OpenCodeNodeStore: ObservableObject {
     }
 
     func delete(_ node: OpenCodeNode) throws {
-        if node.id == activeNodeId {
+        if activeNodeIds.contains(node.id) {
             // 恢复失败时必须保留节点和恢复入口，不能留下“节点已删、接管会话仍在”的孤儿状态。
-            try deactivate()
+            try deactivate(node)
         }
         if proxyOnlyNodeIds.contains(node.id) {
             stopProxyOnly(node)
@@ -197,9 +205,13 @@ final class OpenCodeNodeStore: ObservableObject {
         } catch {
             openCodeStoreLog.error("Failed to save OpenCode global config: \(String(describing: error), privacy: .public)")
         }
-        // 通用配置变化即时反映到生效中的节点。
-        if let node = activeNode {
-            Task { try? await activate(node) }
+        // 通用配置变化即时反映到生效中的节点（全量重写所有激活节点）。
+        if !activeNodeIds.isEmpty {
+            do {
+                try rewriteManagedConfig()
+            } catch {
+                openCodeStoreLog.error("Failed to reapply common config: \(String(describing: error), privacy: .public)")
+            }
         }
     }
 
@@ -219,10 +231,10 @@ final class OpenCodeNodeStore: ObservableObject {
     /// outside AIUsage. Normal deactivation remains fail-closed.
     func discardExternalConfigChanges() throws {
         try configManager.restoreDiscardingExternalChanges()
-        if let active = activeNode, active.proxyEnabled, !proxyOnlyNodeIds.contains(active.id) {
-            proxyRuntime.stop(nodeId: active.id)
+        for node in activeNodes where node.proxyEnabled && !proxyOnlyNodeIds.contains(node.id) {
+            proxyRuntime.stop(nodeId: node.id)
         }
-        activeNodeId = nil
+        activeNodeIds.removeAll()
         save()
         objectWillChange.send()
     }
@@ -234,7 +246,6 @@ final class OpenCodeNodeStore: ObservableObject {
         if GlobalProxyManager.opencode.config.isEnabled {
             throw OpenCodeNodeStoreError.managedByGlobalProxy
         }
-        let common = commonSettings(for: node)
         if node.proxyEnabled {
             // Codex 轨道（responses 透传）启动时强制要求 Key，缺失会让 QuotaServer
             // 静默不挂载代理路由，请求全 404——提前拦截给出可读错误。
@@ -245,23 +256,48 @@ final class OpenCodeNodeStore: ObservableObject {
             if proxyOnlyNodeIds.remove(node.id) != nil {
                 save()
             }
-            stopPreviousActiveProxyProcess(except: node.id)
-            // 代理模式：先拉起本地透传进程，再把受管层指向它；写配置失败则回收进程。
+            // 代理模式：先拉起本地透传进程，再把受管层指向它；写配置失败则回收进程并回滚激活状态。
             try await proxyRuntime.start(node: node)
+            let previousIds = activeNodeIds
+            activeNodeIds.removeAll { $0 == node.id }
+            activeNodeIds.append(node.id)
             do {
-                try configManager.activate(node: node, baseURLOverride: node.proxyLocalBaseURL, commonSettings: common)
+                try rewriteManagedConfig()
             } catch {
+                activeNodeIds = previousIds
                 proxyRuntime.stop(nodeId: node.id)
                 throw error
             }
         } else {
-            stopPreviousActiveProxyProcess(except: node.id)
-            try configManager.activate(node: node, commonSettings: common)
+            let previousIds = activeNodeIds
+            activeNodeIds.removeAll { $0 == node.id }
+            activeNodeIds.append(node.id)
+            do {
+                try rewriteManagedConfig()
+            } catch {
+                activeNodeIds = previousIds
+                throw error
+            }
         }
         if let index = nodes.firstIndex(where: { $0.id == node.id }) {
             nodes[index].lastUsedAt = Date()
         }
-        activeNodeId = node.id
+        save()
+        objectWillChange.send()
+    }
+
+    /// 停用单个节点（issue #66）：仍有其它激活节点时重写配置，否则还原受管层。
+    func deactivate(_ node: OpenCodeNode) throws {
+        guard activeNodeIds.contains(node.id) else { return }
+        activeNodeIds.removeAll { $0 == node.id }
+        if node.proxyEnabled, !proxyOnlyNodeIds.contains(node.id) {
+            proxyRuntime.stop(nodeId: node.id)
+        }
+        if activeNodeIds.isEmpty {
+            try configManager.restore()
+        } else {
+            try rewriteManagedConfig()
+        }
         save()
         objectWillChange.send()
     }
@@ -269,21 +305,28 @@ final class OpenCodeNodeStore: ObservableObject {
     func deactivate() throws {
         try configManager.restore()
         // 先成功恢复配置再停代理；恢复被外部修改拦截时保持原路由可用。
-        if let active = activeNode, active.proxyEnabled, !proxyOnlyNodeIds.contains(active.id) {
-            proxyRuntime.stop(nodeId: active.id)
+        for node in activeNodes where node.proxyEnabled && !proxyOnlyNodeIds.contains(node.id) {
+            proxyRuntime.stop(nodeId: node.id)
         }
-        activeNodeId = nil
+        activeNodeIds.removeAll()
         save()
         objectWillChange.send()
     }
 
-    /// 切换激活目标时回收上一个激活的代理节点进程（其进程随激活存在，
-    /// 不属于仅代理集合时没人再需要它）。
-    private func stopPreviousActiveProxyProcess(except newId: String) {
-        guard let previous = activeNode, previous.proxyEnabled,
-              previous.id != newId,
-              !proxyOnlyNodeIds.contains(previous.id) else { return }
-        proxyRuntime.stop(nodeId: previous.id)
+    /// 全量重写受管配置：把 activeNodeIds 对应的所有节点 provider 块注入 opencode 配置，
+    /// 顶层 model 指向最近激活节点（activeNodeIds 末位）。
+    private func rewriteManagedConfig() throws {
+        let activeNodes = activeNodeIds.compactMap { id in nodes.first { $0.id == id } }
+        guard !activeNodes.isEmpty else {
+            try configManager.restore()
+            return
+        }
+        try configManager.activate(
+            nodes: activeNodes,
+            defaultNodeId: activeNodeIds.last ?? activeNodes[0].id
+        ) { [weak self] node in
+            self?.commonSettings(for: node)
+        }
     }
 
     // MARK: - Proxy-Only Mode
@@ -300,7 +343,7 @@ final class OpenCodeNodeStore: ObservableObject {
     }
 
     func startProxyOnly(_ node: OpenCodeNode) async throws {
-        guard node.proxyEnabled, node.id != activeNodeId else { return }
+        guard node.proxyEnabled, !activeNodeIds.contains(node.id) else { return }
         if node.protocolType == .openAIResponses, node.apiKey.nilIfBlank == nil {
             throw OpenCodeNodeStoreError.proxyRequiresAPIKey
         }
@@ -319,10 +362,10 @@ final class OpenCodeNodeStore: ObservableObject {
     /// 仅代理集合里不存在或已关掉代理模式的节点一并清理。
     func reconcileWithConfigFile() {
         var changed = false
-        if activeNodeId != nil,
+        if !activeNodeIds.isEmpty,
            configManager.managementState == .unmanaged,
            !configManager.isManaged {
-            activeNodeId = nil
+            activeNodeIds.removeAll()
             changed = true
         }
         let validProxyOnlyIds = proxyOnlyNodeIds.filter { id in
@@ -342,7 +385,7 @@ final class OpenCodeNodeStore: ObservableObject {
         // 与 Claude/Codex 一致：受「启动时自动恢复代理」设置控制。关闭时不接管，
         // 并还原受管配置层（避免它仍指向不会被拉起的本地端口）。
         guard AppSettings.shared.proxyAutoRestoreOnLaunch else {
-            if activeNodeId != nil {
+            if !activeNodeIds.isEmpty {
                 do { try deactivate() } catch {
                     openCodeStoreLog.error("Failed to deactivate OpenCode node while auto-restore disabled: \(SensitiveDataRedactor.redactedMessage(for: error), privacy: .public)")
                 }
@@ -358,10 +401,10 @@ final class OpenCodeNodeStore: ObservableObject {
         guard state == .managed || (state == .unmanaged && configManager.isManaged) else { return }
 
         var toRestore: [OpenCodeNode] = []
-        if let active = activeNode, active.proxyEnabled {
-            toRestore.append(active)
+        for node in activeNodes where node.proxyEnabled {
+            toRestore.append(node)
         }
-        for id in proxyOnlyNodeIds where id != activeNodeId {
+        for id in proxyOnlyNodeIds where !activeNodeIds.contains(id) {
             if let node = nodes.first(where: { $0.id == id && $0.proxyEnabled }) {
                 toRestore.append(node)
             }
@@ -470,7 +513,7 @@ final class OpenCodeNodeStore: ObservableObject {
         do {
             let file = try JSONDecoder.profileDecoder.decode(StoreFile.self, from: data)
             nodes = file.nodes
-            activeNodeId = file.activeNodeId
+            activeNodeIds = file.activeNodeIds ?? (file.activeNodeId.map { [$0] } ?? [])
             proxyOnlyNodeIds = Set(file.proxyOnlyNodeIds ?? [])
             sortNodes()
             backfillProviderSlugs()
@@ -495,7 +538,8 @@ final class OpenCodeNodeStore: ObservableObject {
         let file = StoreFile(
             version: Self.storeVersion,
             nodes: nodes,
-            activeNodeId: activeNodeId,
+            activeNodeId: activeNodeIds.last,
+            activeNodeIds: activeNodeIds.isEmpty ? nil : activeNodeIds,
             proxyOnlyNodeIds: proxyOnlyNodeIds.isEmpty ? nil : Array(proxyOnlyNodeIds).sorted()
         )
         do {

--- a/AIUsage/ViewModels/ProviderRefreshCoordinator.swift
+++ b/AIUsage/ViewModels/ProviderRefreshCoordinator.swift
@@ -28,6 +28,7 @@ final class ProviderRefreshCoordinator: ObservableObject {
     let engine = ProviderEngine()
     private var refreshTimer: Timer?
     private var claudeCodeRefreshTimer: Timer?
+    private var callAnalyticsSyncTimer: Timer?
     private var isCodexFullHistoryRefreshInProgress = false
 
     /// Used by toolbar / menu bar "Refresh All" buttons to decide between the
@@ -55,6 +56,7 @@ final class ProviderRefreshCoordinator: ObservableObject {
     private init() {
         setupAutoRefresh()
         setupClaudeCodeAutoRefresh()
+        setupCallAnalyticsAutoSync()
     }
 
     func configure(
@@ -96,6 +98,21 @@ final class ProviderRefreshCoordinator: ObservableObject {
             claudeCodeRefreshTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(settings.claudeCodeRefreshInterval), repeats: true) { [weak self] _ in
                 self?.refreshLocalTokenStatsOnly()
             }
+        }
+    }
+
+    func setupCallAnalyticsAutoSync() {
+        callAnalyticsSyncTimer?.invalidate()
+        if settings.autoRefreshInterval > 0 {
+            callAnalyticsSyncTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(settings.autoRefreshInterval), repeats: true) { [weak self] _ in
+                self?.syncCallAnalytics()
+            }
+        }
+    }
+
+    private func syncCallAnalytics() {
+        Task {
+            await CallAnalyticsEngine.shared.syncToday()
         }
     }
 

--- a/AIUsage/ViewModels/ProviderRefreshCoordinator.swift
+++ b/AIUsage/ViewModels/ProviderRefreshCoordinator.swift
@@ -103,6 +103,11 @@ final class ProviderRefreshCoordinator: ObservableObject {
 
     func setupCallAnalyticsAutoSync() {
         callAnalyticsSyncTimer?.invalidate()
+        let normalized = AppSettings.normalizedAutoRefreshInterval(settings.autoRefreshInterval)
+        if settings.autoRefreshInterval != normalized {
+            settings.autoRefreshInterval = normalized
+        }
+
         if settings.autoRefreshInterval > 0 {
             callAnalyticsSyncTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(settings.autoRefreshInterval), repeats: true) { [weak self] _ in
                 self?.syncCallAnalytics()

--- a/AIUsage/Views/CallAnalyticsView.swift
+++ b/AIUsage/Views/CallAnalyticsView.swift
@@ -159,7 +159,7 @@ struct CallAnalyticsView: View {
         .appPageChrome(colorScheme)
         .task(id: rangeSpec.rangeKey) {
             let spec = rangeSpec
-            await store.refreshIfNeeded(rangeKey: spec.rangeKey, cutoff: spec.cutoff, end: spec.end)
+            await store.refresh(rangeKey: spec.rangeKey, cutoff: spec.cutoff, end: spec.end)
         }
     }
 

--- a/AIUsage/Views/JSONRawEditorView.swift
+++ b/AIUsage/Views/JSONRawEditorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import WebKit
+import QuotaBackend
 
 // MARK: - JSON Raw Editor View
 // Full-screen code editor for raw JSON editing of settings.json content.
@@ -13,6 +14,7 @@ struct JSONRawEditorView: View {
     var title: String = L("settings.json", "settings.json")
     var isEditable: Bool = true
     var showsActions: Bool = true
+    var isJSONC: Bool = false
     var lineMarkers: [Int: String] = [:]
     @State private var lineCount: Int = 1
     @State private var showValidationSuccess = false
@@ -95,6 +97,15 @@ struct JSONRawEditorView: View {
 
     private func formatJSON() {
         showValidationSuccess = false
+        if isJSONC {
+            guard let formatted = JSONCEditor.format(jsonText) else {
+                error = L("Cannot format: invalid JSONC", "无法格式化：JSONC 格式无效")
+                return
+            }
+            jsonText = formatted
+            error = nil
+            return
+        }
         guard let data = jsonText.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data),
               let formatted = try? JSONSerialization.data(
@@ -110,6 +121,19 @@ struct JSONRawEditorView: View {
     }
 
     private func validateJSON() {
+        if isJSONC {
+            if JSONCEditor.parseObject(jsonText) != nil {
+                error = nil
+                withAnimation(.easeInOut(duration: 0.25)) { showValidationSuccess = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                    withAnimation(.easeOut(duration: 0.3)) { showValidationSuccess = false }
+                }
+            } else {
+                error = L("Root must be a valid JSONC object", "根节点必须是有效的 JSONC 对象")
+                showValidationSuccess = false
+            }
+            return
+        }
         guard let data = jsonText.data(using: .utf8) else {
             error = L("Invalid encoding", "编码无效")
             showValidationSuccess = false

--- a/AIUsage/Views/LocalSettingsEditorView.swift
+++ b/AIUsage/Views/LocalSettingsEditorView.swift
@@ -35,7 +35,7 @@ struct LocalSettingsEditorView: View {
         VStack(spacing: 0) {
             headerBar
             Divider()
-            JSONRawEditorView(jsonText: $jsonText, error: $jsonError)
+            JSONRawEditorView(jsonText: $jsonText, error: $jsonError, isJSONC: filePath.hasSuffix(".jsonc"))
                 .onChange(of: jsonText) { _, _ in
                     guard !isLoadingFile else { return }
                     hasUnsavedChanges = true

--- a/AIUsage/Views/MenuBarView+TrackSwitcher.swift
+++ b/AIUsage/Views/MenuBarView+TrackSwitcher.swift
@@ -211,7 +211,7 @@ extension MenuBarView {
         let globalEnabled = manager.isEnabled
         let globalNodes = manager.availableNodes()
         let accent = OpenCodeManagementView.brand
-        let activeId = openCodeStore.activeNodeId
+        let activeId = openCodeStore.activeNodeIds.last
 
         var sections: [MenuBarTrackPanelSection] = []
         var onDeactivate: (() -> Void)?
@@ -220,18 +220,18 @@ extension MenuBarView {
             sections = [hotSwapSection(manager: manager, nodes: globalNodes)]
         } else {
             let rows = openCodeStore.nodes.map { node -> MenuBarTrackPanelRow in
-                let isActive = openCodeStore.activeNodeId == node.id
+                let isActive = openCodeStore.activeNodeIds.contains(node.id)
                 return MenuBarTrackPanelRow(
                     id: node.id, name: node.displayName, isActive: isActive,
                     isDisabled: !node.isComplete
                 ) {
-                    if isActive { try? openCodeStore.deactivate() }
+                    if isActive { try? openCodeStore.deactivate(node) }
                     else { Task { try? await openCodeStore.activate(node) } }
                     closePanel()
                 }
             }
             sections = [MenuBarTrackPanelSection(id: "nodes", rows: rows)]
-            if activeId != nil {
+            if !openCodeStore.activeNodeIds.isEmpty {
                 onDeactivate = { try? openCodeStore.deactivate(); closePanel() }
             }
         }

--- a/AIUsage/Views/ModelExtraParametersEditor.swift
+++ b/AIUsage/Views/ModelExtraParametersEditor.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// 可复用的 per-model key-value 参数编辑器（issue #69）。
+/// 编辑 `[String: String]` 形式的任意追加参数，供 OpenCode 节点模型行与
+/// 统一 API Provider 模型库两处复用；值存字符串，生成时由配置管理器智能解析。
+struct ModelExtraParametersEditor: View {
+    @Binding var parameters: [String: String]
+    @State private var rows: [Row] = []
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var key = ""
+        var value = ""
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach($rows) { $row in
+                HStack(spacing: 6) {
+                    TextField(L("key", "键"), text: $row.key)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled()
+                    TextField(L("value", "值"), text: $row.value)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled()
+                    Button {
+                        rows.removeAll { $0.id == $row.wrappedValue.id }
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.red.opacity(0.7))
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: 20)
+                    .help(L("Remove parameter", "移除参数"))
+                }
+            }
+            Button {
+                rows.append(Row())
+            } label: {
+                Label(L("Add parameter", "添加参数"), systemImage: "plus.circle")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+        }
+        .onAppear { loadIfNeeded() }
+        .onChange(of: rows) { _, _ in persist() }
+    }
+
+    private func loadIfNeeded() {
+        guard rows.isEmpty else { return }
+        rows = parameters
+            .map { Row(key: $0.key, value: $0.value) }
+            .sorted { $0.key < $1.key }
+    }
+
+    private func persist() {
+        var next: [String: String] = [:]
+        for row in rows {
+            let key = row.key.trimmingCharacters(in: .whitespaces)
+            if !key.isEmpty { next[key] = row.value }
+        }
+        if next != parameters { parameters = next }
+    }
+}

--- a/AIUsage/Views/OpenCodeDefaultModelNodeSection.swift
+++ b/AIUsage/Views/OpenCodeDefaultModelNodeSection.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+// MARK: - OpenCode Default Model Node Section
+// 「默认模型节点」独立卡片（与通用配置解耦）：多节点同时激活时，顶层 model 指向
+// 显式选择的节点；未选择（Auto）时回退到第一个激活节点；全部停用时由父视图隐藏。
+
+struct OpenCodeDefaultModelNodeSection: View {
+    @ObservedObject var store: OpenCodeNodeStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "star.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.yellow)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("Default model node", "默认模型节点"))
+                    .font(.subheadline.weight(.semibold))
+                Text(L("Top-level model follows the selected active node", "顶层模型跟随所选激活节点"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Picker("", selection: Binding<String?>(
+                get: { store.openCodeDefaultNodeId },
+                set: { store.setOpenCodeDefaultNodeId($0) }
+            )) {
+                Text(L("Auto (first active node)", "自动（第一个激活节点）"))
+                    .tag(nil as String?)
+                ForEach(store.activeNodes, id: \.id) { node in
+                    Text(node.displayName).tag(node.id as String?)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .fixedSize()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(AppSurface.card(colorScheme))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(AppStroke.card(colorScheme), lineWidth: 1)
+        )
+    }
+}

--- a/AIUsage/Views/OpenCodeGlobalConfigSection.swift
+++ b/AIUsage/Views/OpenCodeGlobalConfigSection.swift
@@ -15,52 +15,58 @@ struct OpenCodeGlobalConfigSection: View {
     private var targetFileName: String { store.configFileName }
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "gearshape.2.fill")
-                .font(.system(size: 14))
-                .foregroundStyle(.orange)
+        VStack(spacing: 10) {
+            HStack(spacing: 12) {
+                Image(systemName: "gearshape.2.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.orange)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(L("Common Config", "通用配置"))
-                    .font(.subheadline.weight(.semibold))
-                Text(keyCount > 0
-                     ? L("\(keyCount) top-level keys", "\(keyCount) 个顶层字段")
-                     : L("Not configured", "未配置"))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            Button {
-                showingEditor = true
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "pencil.line")
-                        .font(.system(size: 10, weight: .semibold))
-                    Text(L("Edit", "编辑"))
-                        .font(.system(size: 11, weight: .semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Common Config", "通用配置"))
+                        .font(.subheadline.weight(.semibold))
+                    Text(keyCount > 0
+                         ? L("\(keyCount) top-level keys", "\(keyCount) 个顶层字段")
+                         : L("Not configured", "未配置"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 5)
-                .background(Capsule().fill(Color.primary.opacity(0.06)))
-            }
-            .buttonStyle(.plain)
 
-            Toggle(isOn: Binding(
-                get: { store.globalConfig.enabled },
-                set: { newValue in
-                    store.globalConfig.enabled = newValue
-                    store.saveGlobalConfig()
-                }
-            )) {
-                Text(L("Merge", "合并"))
-                    .font(.caption.weight(.medium))
+                Spacer()
+
+                Button {
+                    showingEditor = true
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "pencil.line")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(L("Edit", "编辑"))
+                            .font(.system(size: 11, weight: .semibold))
+                    }
                     .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Color.primary.opacity(0.06)))
+                }
+                .buttonStyle(.plain)
+
+                Toggle(isOn: Binding(
+                    get: { store.globalConfig.enabled },
+                    set: { newValue in
+                        store.globalConfig.enabled = newValue
+                        store.saveGlobalConfig()
+                    }
+                )) {
+                    Text(L("Merge", "合并"))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
+                .toggleStyle(.switch)
+                .controlSize(.small)
             }
-            .toggleStyle(.switch)
-            .controlSize(.small)
+
+            if !store.activeNodeIds.isEmpty {
+                defaultNodePicker
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -74,6 +80,34 @@ struct OpenCodeGlobalConfigSection: View {
         )
         .sheet(isPresented: $showingEditor) {
             OpenCodeGlobalConfigEditorView(store: store)
+        }
+    }
+
+    private var defaultNodePicker: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "star.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(.yellow)
+            Text(L("Default model node", "默认模型节点"))
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Picker("", selection: Binding<String?>(
+                get: { store.globalConfig.openCodeDefaultNodeId },
+                set: { newValue in
+                    store.globalConfig.openCodeDefaultNodeId = newValue
+                    store.saveGlobalConfig()
+                }
+            )) {
+                Text(L("Auto (first active node)", "自动（第一个激活节点）"))
+                    .tag(nil as String?)
+                ForEach(store.activeNodes, id: \.id) { node in
+                    Text(node.displayName).tag(node.id as String?)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .fixedSize()
         }
     }
 }

--- a/AIUsage/Views/OpenCodeGlobalConfigSection.swift
+++ b/AIUsage/Views/OpenCodeGlobalConfigSection.swift
@@ -15,58 +15,52 @@ struct OpenCodeGlobalConfigSection: View {
     private var targetFileName: String { store.configFileName }
 
     var body: some View {
-        VStack(spacing: 10) {
-            HStack(spacing: 12) {
-                Image(systemName: "gearshape.2.fill")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.orange)
+        HStack(spacing: 12) {
+            Image(systemName: "gearshape.2.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.orange)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(L("Common Config", "通用配置"))
-                        .font(.subheadline.weight(.semibold))
-                    Text(keyCount > 0
-                         ? L("\(keyCount) top-level keys", "\(keyCount) 个顶层字段")
-                         : L("Not configured", "未配置"))
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                Button {
-                    showingEditor = true
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "pencil.line")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text(L("Edit", "编辑"))
-                            .font(.system(size: 11, weight: .semibold))
-                    }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("Common Config", "通用配置"))
+                    .font(.subheadline.weight(.semibold))
+                Text(keyCount > 0
+                     ? L("\(keyCount) top-level keys", "\(keyCount) 个顶层字段")
+                     : L("Not configured", "未配置"))
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(Capsule().fill(Color.primary.opacity(0.06)))
-                }
-                .buttonStyle(.plain)
-
-                Toggle(isOn: Binding(
-                    get: { store.globalConfig.enabled },
-                    set: { newValue in
-                        store.globalConfig.enabled = newValue
-                        store.saveGlobalConfig()
-                    }
-                )) {
-                    Text(L("Merge", "合并"))
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
-                }
-                .toggleStyle(.switch)
-                .controlSize(.small)
             }
 
-            if !store.activeNodeIds.isEmpty {
-                defaultNodePicker
+            Spacer()
+
+            Button {
+                showingEditor = true
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "pencil.line")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text(L("Edit", "编辑"))
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(Capsule().fill(Color.primary.opacity(0.06)))
             }
+            .buttonStyle(.plain)
+
+            Toggle(isOn: Binding(
+                get: { store.globalConfig.enabled },
+                set: { newValue in
+                    store.globalConfig.enabled = newValue
+                    store.saveGlobalConfig()
+                }
+            )) {
+                Text(L("Merge", "合并"))
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+            .toggleStyle(.switch)
+            .controlSize(.small)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -80,34 +74,6 @@ struct OpenCodeGlobalConfigSection: View {
         )
         .sheet(isPresented: $showingEditor) {
             OpenCodeGlobalConfigEditorView(store: store)
-        }
-    }
-
-    private var defaultNodePicker: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "star.fill")
-                .font(.system(size: 11))
-                .foregroundStyle(.yellow)
-            Text(L("Default model node", "默认模型节点"))
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
-            Spacer()
-            Picker("", selection: Binding<String?>(
-                get: { store.globalConfig.openCodeDefaultNodeId },
-                set: { newValue in
-                    store.globalConfig.openCodeDefaultNodeId = newValue
-                    store.saveGlobalConfig()
-                }
-            )) {
-                Text(L("Auto (first active node)", "自动（第一个激活节点）"))
-                    .tag(nil as String?)
-                ForEach(store.activeNodes, id: \.id) { node in
-                    Text(node.displayName).tag(node.id as String?)
-                }
-            }
-            .pickerStyle(.menu)
-            .labelsHidden()
-            .fixedSize()
         }
     }
 }

--- a/AIUsage/Views/OpenCodeManagementView.swift
+++ b/AIUsage/Views/OpenCodeManagementView.swift
@@ -375,7 +375,13 @@ struct OpenCodeManagementView: View {
 
     private func toggleActivation(_ node: OpenCodeNode) {
         if store.activeNodeIds.contains(node.id) {
-            deactivate(node)
+            do {
+                try store.deactivate(node)
+                statsStore.refresh()
+            } catch {
+                store.refreshConfigContext()
+                actionError = error.localizedDescription
+            }
         } else {
             activate(node)
         }

--- a/AIUsage/Views/OpenCodeManagementView.swift
+++ b/AIUsage/Views/OpenCodeManagementView.swift
@@ -53,6 +53,9 @@ struct OpenCodeManagementView: View {
                         actionBar
                         OpenCodeOverviewStrip(store: store, statsStore: statsStore, proxyRuntime: proxyRuntime)
                         OpenCodeGlobalConfigSection(store: store)
+                        if !store.activeNodeIds.isEmpty {
+                            OpenCodeDefaultModelNodeSection(store: store)
+                        }
                         OpenCodeGlobalProxySection()
                         nodeListSection
                     }

--- a/AIUsage/Views/OpenCodeManagementView.swift
+++ b/AIUsage/Views/OpenCodeManagementView.swift
@@ -220,7 +220,7 @@ struct OpenCodeManagementView: View {
         let mergedLastUsed = [stats?.lastUsedAt, global?.lastRequestAt].compactMap { $0 }.max()
         return OpenCodeNodeCard(
             node: node,
-            isActive: node.id == store.activeNodeId,
+            isActive: store.activeNodeIds.contains(node.id),
             isProxyOnlyRunning: store.proxyOnlyNodeIds.contains(node.id),
             isSelected: isSelected,
             isBusy: activationInProgress,
@@ -374,8 +374,8 @@ struct OpenCodeManagementView: View {
     // MARK: - Actions
 
     private func toggleActivation(_ node: OpenCodeNode) {
-        if node.id == store.activeNodeId {
-            deactivate()
+        if store.activeNodeIds.contains(node.id) {
+            deactivate(node)
         } else {
             activate(node)
         }

--- a/AIUsage/Views/OpenCodeNodeEditorView.swift
+++ b/AIUsage/Views/OpenCodeNodeEditorView.swift
@@ -442,6 +442,7 @@ struct OpenCodeNodeEditorView: View {
         let rowId = row.wrappedValue.id
         let isExpanded = expandedModalityRows.contains(rowId)
         let hasModalities = row.wrappedValue.entry.hasModalities
+        let hasExtraParameters = !row.wrappedValue.entry.extraParameters.isEmpty
         return VStack(spacing: 6) {
             HStack(spacing: 6) {
                 Button {
@@ -478,13 +479,14 @@ struct OpenCodeNodeEditorView: View {
                     if isExpanded { expandedModalityRows.remove(rowId) }
                     else { expandedModalityRows.insert(rowId) }
                 } label: {
-                    Image(systemName: hasModalities ? "square.stack.3d.up.fill" : "square.stack.3d.up")
+                    let hasAdvanced = hasModalities || hasExtraParameters
+                    Image(systemName: hasAdvanced ? "square.stack.3d.up.fill" : "square.stack.3d.up")
                         .font(.system(size: 12))
-                        .foregroundStyle(hasModalities ? Self.brand : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
+                        .foregroundStyle(hasAdvanced ? Self.brand : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
                 }
                 .buttonStyle(.plain)
                 .frame(width: 20)
-                .help(L("Configure modalities for this model", "为该模型配置模态（输入/输出）"))
+                .help(L("Configure advanced options for this model", "为该模型配置模态与追加参数"))
 
                 Button {
                     modelRows.removeAll { $0.id == row.wrappedValue.id }
@@ -506,7 +508,7 @@ struct OpenCodeNodeEditorView: View {
         }
     }
 
-    /// 单个模型的 modalities 配置面板：输入/输出两组可多选的模态芯片（issue #24）。
+    /// 单个模型的高级配置面板：modalities（输入/输出模态）+ 任意追加参数（issue #24 / #69）。
     private func modalityEditor(_ row: Binding<OpenCodeNodeEditorView.ModelRow>) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             modalityRow(
@@ -522,6 +524,18 @@ struct OpenCodeNodeEditorView: View {
             Text(L(
                 "Leave empty to use the model's defaults. Written into the model's modalities block in the active OpenCode config.",
                 "留空则使用模型默认值。会写入当前 OpenCode 配置中该模型的 modalities 块。"
+            ))
+            .font(.system(size: 10))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+            Divider()
+            Text(L("Extra parameters", "追加参数"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            ModelExtraParametersEditor(parameters: row.entry.extraParameters)
+            Text(L(
+                "Keys support dot paths (e.g. \"limit.context\") or top-level keys (e.g. \"temperature\"). Written into this model's config, overriding node-level defaults.",
+                "键支持点路径（如 \"limit.context\"）或顶级键（如 \"temperature\"），会写入该模型配置并覆盖节点级默认值。"
             ))
             .font(.system(size: 10))
             .foregroundStyle(.tertiary)

--- a/AIUsage/Views/OpenCodeNodeStatsSection.swift
+++ b/AIUsage/Views/OpenCodeNodeStatsSection.swift
@@ -29,7 +29,7 @@ struct OpenCodeOverviewStrip: View {
             cell(
                 icon: "checkmark.circle.fill",
                 title: L("Active", "已激活"),
-                value: store.activeNodeId != nil ? "1" : "0",
+                value: "\(store.activeNodeIds.count)",
                 tint: .green
             )
             cell(

--- a/AIUsage/Views/ProxyModelLibraryEditor.swift
+++ b/AIUsage/Views/ProxyModelLibraryEditor.swift
@@ -546,6 +546,7 @@ struct ProviderModelLibraryEditor: View {
     }
 
     @State private var rows: [Row]
+    @State private var expandedExtraRows: Set<UUID> = []
 
     init(
         library: Binding<[ProxyConfiguration.MappedModel]>,
@@ -647,7 +648,11 @@ struct ProviderModelLibraryEditor: View {
     private var rowsFingerprint: [String] {
         rows.map { row in
             let p = row.model.pricing
-            return "\(row.model.name)|\(p.inputPerMillion)|\(p.outputPerMillion)|\(p.cacheCreatePerMillion)|\(p.cacheReadPerMillion)|\(p.currency.rawValue)|\(p.source?.kind.rawValue ?? "")"
+            let extra = row.model.extraParameters
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: ",")
+            return "\(row.model.name)|\(p.inputPerMillion)|\(p.outputPerMillion)|\(p.cacheCreatePerMillion)|\(p.cacheReadPerMillion)|\(p.currency.rawValue)|\(p.source?.kind.rawValue ?? "")|\(extra)"
         }
     }
 
@@ -666,35 +671,71 @@ struct ProviderModelLibraryEditor: View {
             }
             .frame(width: 64, alignment: .leading)
             Text(L("Source", "来源")).frame(width: 60, alignment: .leading)
-            Spacer().frame(width: 20)
+            Spacer().frame(width: 40)
         }
         .font(.system(size: 10, weight: .medium))
         .foregroundStyle(.tertiary)
     }
 
     private func rowView(_ row: Binding<Row>) -> some View {
-        HStack(spacing: 6) {
-            TextField("gpt-5.5", text: row.model.name)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12, design: .monospaced))
-                .frame(minWidth: 0, maxWidth: .infinity)
-                .layoutPriority(1)
-                .autocorrectionDisabled()
-            providerPriceField(row.model.pricing.inputPerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.outputPerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.cacheCreatePerMillion, pricing: row.model.pricing)
-            providerPriceField(row.model.pricing.cacheReadPerMillion, pricing: row.model.pricing)
-            PricingSourceIndicator(pricing: row.wrappedValue.model.pricing, width: 60)
-            Button {
-                rows.removeAll { $0.id == row.wrappedValue.id }
-            } label: {
-                Image(systemName: "minus.circle.fill")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.red.opacity(0.7))
+        let rowId = row.wrappedValue.id
+        let isExpanded = expandedExtraRows.contains(rowId)
+        let hasExtra = !row.wrappedValue.model.extraParameters.isEmpty
+        return VStack(spacing: 6) {
+            HStack(spacing: 6) {
+                TextField("gpt-5.5", text: row.model.name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .layoutPriority(1)
+                    .autocorrectionDisabled()
+                providerPriceField(row.model.pricing.inputPerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.outputPerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.cacheCreatePerMillion, pricing: row.model.pricing)
+                providerPriceField(row.model.pricing.cacheReadPerMillion, pricing: row.model.pricing)
+                PricingSourceIndicator(pricing: row.wrappedValue.model.pricing, width: 60)
+                Button {
+                    if isExpanded { expandedExtraRows.remove(rowId) }
+                    else { expandedExtraRows.insert(rowId) }
+                } label: {
+                    Image(systemName: hasExtra ? "gearshape.2.fill" : "gearshape.2")
+                        .font(.system(size: 12))
+                        .foregroundStyle(hasExtra ? Color.accentColor : Color.secondary.opacity(isExpanded ? 0.9 : 0.5))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 20)
+                .help(L("Configure extra parameters for this model", "为该模型配置追加参数"))
+                Button {
+                    rows.removeAll { $0.id == rowId }
+                    expandedExtraRows.remove(rowId)
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.red.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 20)
+                .help(L("Remove provider model", "移除提供商模型"))
             }
-            .buttonStyle(.plain)
-            .frame(width: 20)
-            .help(L("Remove provider model", "移除提供商模型"))
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    ModelExtraParametersEditor(parameters: row.model.extraParameters)
+                    Text(L(
+                        "Keys support dot paths (e.g. \"limit.context\") or top-level keys (e.g. \"temperature\"). Written into this model's config, overriding node-level defaults.",
+                        "键支持点路径（如 \"limit.context\"）或顶级键（如 \"temperature\"），会写入该模型配置并覆盖节点级默认值。"
+                    ))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.primary.opacity(0.04))
+                )
+                .padding(.leading, 24)
+            }
         }
     }
 

--- a/AIUsage/Views/SettingsView.swift
+++ b/AIUsage/Views/SettingsView.swift
@@ -161,6 +161,7 @@ struct SettingsView: View {
         .onChange(of: settings.autoRefreshInterval) { _, _ in
             settings.saveSettings()
             refreshCoordinator.setupAutoRefresh()
+            refreshCoordinator.setupCallAnalyticsAutoSync()
         }
         .onChange(of: settings.claudeCodeRefreshInterval) { _, _ in
             settings.saveSettings()

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -13,6 +13,8 @@ public actor CallAnalyticsEngine {
     let environment: [String: String]
     /// 永久每日冻结归档（issue #32）：删 session 后历史调用统计不丢。仅本 actor 访问，串行安全。
     private let archive: CallAnalyticsArchiveStore
+    /// OpenCode 明细账本（issue #67 调用分析部分）：按 part.id upsert、读不到的不删，删 session 后调用明细不丢。
+    private let opencodeLedger: OpenCodeCallLedgerStore
 
     public init(
         homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
@@ -23,6 +25,7 @@ public actor CallAnalyticsEngine {
         self.timeZone = timeZone
         self.environment = environment
         self.archive = CallAnalyticsArchiveStore(homeDirectory: homeDirectory)
+        self.opencodeLedger = OpenCodeCallLedgerStore(homeDirectory: homeDirectory)
     }
 
     /// 计算调用分析快照。
@@ -52,16 +55,21 @@ public actor CallAnalyticsEngine {
             .collect(cutoff: scanCutoff)
         let codex = CodexCallEventSource(homeDirectory: homeDirectory, timeZone: timeZone, environment: environment)
             .collect(cutoff: scanCutoff)
-        let opencode = OpenCodeCallEventSource(
+        let opencodeRaw = OpenCodeCallEventSource(
             homeDirectory: homeDirectory, timeZone: timeZone, environment: environment,
             knownMCPServers: openCodeServers
         ).collect(cutoff: scanCutoff)
+
+        // OpenCode 明细账本：issue #67 调用分析部分。按 part.id upsert、读不到的不删，
+        // 使删除 opencode 会话后已记录的调用明细不丢；再从账本聚合回计数条目。
+        let opencodeLedgerEntries = opencodeLedger.merge(newEntries: opencodeRaw.entries, completedFullHistory: needsFullImport)
+        let opencodeEntries = OpenCodeCallLedgerStore.aggregate(opencodeLedgerEntries)
 
         // 实时结果按日分桶（entries 自带 dayKey；Claude 的 agentInvocations 已按天归属）。
         var computed: [String: CallAnalyticsDayBucket] = [:]
         for entry in claude.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
         for entry in codex.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
-        for entry in opencode.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
+        for entry in opencodeEntries { computed[entry.dayKey, default: .empty].entries.append(entry) }
         for (day, invs) in claude.agentInvocationsByDay {
             computed[day, default: .empty].agentInvocations.append(contentsOf: invs)
         }
@@ -88,7 +96,7 @@ public actor CallAnalyticsEngine {
 
         // 各源对外展示的「调用次数」以归档展示条目为准，避免页脚 M 次调用与上方 KPI 对不上；
         // available / filesScanned / errorCode 沿用本次实时扫描状态。
-        let rawStatuses = [claude.status, codex.status, opencode.status]
+        let rawStatuses = [claude.status, codex.status, opencodeRaw.status]
         let statuses = rawStatuses.map { status -> CallSourceStatus in
             let count = entries.filter { $0.source == status.source }.reduce(0) { $0 + $1.count }
             return CallSourceStatus(

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -119,6 +119,16 @@ public actor CallAnalyticsEngine {
         )
     }
 
+    /// 后台定时同步（菜单栏常驻场景）：以「今天」为窗口跑一次完整扫描，把 OpenCode 调用明细
+    /// 增量写入账本并冻结归档。不打开「调用分析」页也能持续记录，删除会话后已记录调用不丢。
+    /// 复用 computeSnapshot 的账本 merge + 归档 freeze 副作用，丢弃展示快照；
+    /// 频率由 App 侧 autoRefreshInterval 控制（默认 300s）。
+    public func syncToday() {
+        let clock = CallAnalyticsClock(timeZone: timeZone)
+        let todayStart = clock.calendar.startOfDay(for: Date())
+        _ = computeSnapshot(rangeKey: "today", cutoff: todayStart, end: nil)
+    }
+
     /// agentInvocations 跨日聚合键。
     private struct AgentInvocationKey: Hashable {
         let source: CallSourceKind

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -48,7 +48,9 @@ public actor CallAnalyticsEngine {
         let openCodeServers = Set(installedMCP.filter { $0.source == .opencode }.map(\.name))
 
         // 首次：扫全历史以冻结所有过去日（之后只扫请求窗口即可，省 IO）。
-        let needsFullImport = !archive.fullHistoryImported
+        // OpenCode 明细账本与日聚合归档是两套独立的全量导入标记：老用户 archive 可能已完成
+        // 导入，但新增的 opencode 账本尚未全量回填历史，此时仍需全量扫描，否则账本缺历史明细。
+        let needsFullImport = !archive.fullHistoryImported || !opencodeLedger.fullHistoryImported
         let scanCutoff: Date? = needsFullImport ? nil : cutoff
 
         let claude = ClaudeCallEventSource(homeDirectory: homeDirectory, timeZone: timeZone, environment: environment)

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -94,10 +94,13 @@ public actor CallAnalyticsEngine {
 
         // 展示组装：Claude/Codex 从归档（删 session 后过去日仍在，今天随实时刷新）；
         // OpenCode 从账本聚合（含补采回的历史日，且删 session 不丢账）。
-        // 旧归档 OpenCode 去重：账本完成全量回填后，旧归档的 OpenCode 条目按「日」让位账本
-        // （账本优先，避免与首次回填重复）；账本未回填的日（删会话独有）保留旧归档 OpenCode。
-        let ledgerOpenCodeDayKeys = Set(opencodeEntries.map { $0.dayKey })
-        let ledgerFullyImported = opencodeLedger.fullHistoryImported
+        // 旧归档 OpenCode 迁移：账本完成全量回填后，一次性计算旧归档相对账本聚合的残差并持久化，
+        // 之后旧归档 OpenCode 条目让位残差（不再参与展示），避免与首次回填双计，也避免丢删会话独有记录。
+        if opencodeLedger.fullHistoryImported && !opencodeLedger.legacyArchiveMigrated {
+            let legacyOpenCodeEntries = frozenDays.values.flatMap { $0.entries }.filter { $0.source == .opencode }
+            opencodeLedger.migrateLegacyResidual(Self.residualEntries(legacy: legacyOpenCodeEntries, ledger: opencodeEntries))
+        }
+        let residualOpenCodeEntries = opencodeLedger.legacyResidual
         let lowerKey = cutoff.map { clock.dayKey($0) }
         let upperKey = end.map { clock.dayKey($0) }
         var entries: [CallAnalyticsEntry] = []
@@ -107,9 +110,7 @@ public actor CallAnalyticsEngine {
             if let upperKey, day > upperKey { continue }
             let deduped = Self.deduplicateLegacyOpenCode(
                 entries: bucket.entries,
-                day: day,
-                ledgerFullyImported: ledgerFullyImported,
-                ledgerOpenCodeDayKeys: ledgerOpenCodeDayKeys
+                legacyArchiveMigrated: opencodeLedger.legacyArchiveMigrated
             )
             entries.append(contentsOf: deduped)
             for inv in bucket.agentInvocations {
@@ -117,6 +118,11 @@ public actor CallAnalyticsEngine {
             }
         }
         for entry in opencodeEntries {
+            if let lowerKey, entry.dayKey < lowerKey { continue }
+            if let upperKey, entry.dayKey > upperKey { continue }
+            entries.append(entry)
+        }
+        for entry in residualOpenCodeEntries {
             if let lowerKey, entry.dayKey < lowerKey { continue }
             if let upperKey, entry.dayKey > upperKey { continue }
             entries.append(entry)
@@ -178,17 +184,64 @@ public actor CallAnalyticsEngine {
         return fallbackCutoff
     }
 
-    /// 旧归档 OpenCode 条目去重：账本完成全量回填后，旧归档中与账本聚合重叠的 OpenCode 条目
-    /// 让位账本（避免与首次回填双计）；账本未回填的日（删会话独有）保留旧归档 OpenCode。
+    /// 旧归档 OpenCode 条目去重：迁移完成后旧归档的 OpenCode 条目全部让位残差（不再参与展示）；
+    /// 迁移前（账本尚未完成全量回填或迁移尚未发生）保留原样，保证删会话独有历史不丢。
     /// internal（非 private）以便单元测试验证去重规则。
     static func deduplicateLegacyOpenCode(
         entries: [CallAnalyticsEntry],
-        day: String,
-        ledgerFullyImported: Bool,
-        ledgerOpenCodeDayKeys: Set<String>
+        legacyArchiveMigrated: Bool
     ) -> [CallAnalyticsEntry] {
-        guard ledgerFullyImported, ledgerOpenCodeDayKeys.contains(day) else { return entries }
+        guard legacyArchiveMigrated else { return entries }
         return entries.filter { $0.source != .opencode }
+    }
+
+    /// 计算旧归档 OpenCode 条目相对「迁移时账本聚合」的残差：`max(legacy - ledger, 0)`。
+    /// 按 day+source+kind+name+server+agent 逐字段相减钳制（count 与成功率/耗时可累加分量各自独立）。
+    /// internal（非 private）以便单元测试验证残差计算。
+    static func residualEntries(
+        legacy: [CallAnalyticsEntry],
+        ledger: [CallAnalyticsEntry]
+    ) -> [CallAnalyticsEntry] {
+        struct Key: Hashable {
+            let dayKey: String
+            let source: CallSourceKind
+            let kind: CallKind
+            let name: String
+            let server: String?
+            let agent: String?
+        }
+        var ledgerByKey: [Key: CallAnalyticsEntry] = [:]
+        for entry in ledger {
+            ledgerByKey[Key(dayKey: entry.dayKey, source: entry.source, kind: entry.kind, name: entry.name, server: entry.server, agent: entry.agent)] = entry
+        }
+
+        var residual: [CallAnalyticsEntry] = []
+        for legacyEntry in legacy {
+            let key = Key(dayKey: legacyEntry.dayKey, source: legacyEntry.source, kind: legacyEntry.kind, name: legacyEntry.name, server: legacyEntry.server, agent: legacyEntry.agent)
+            let ledgerEntry = ledgerByKey[key]
+            let count = max(legacyEntry.count - (ledgerEntry?.count ?? 0), 0)
+            let outcomeKnown = max(legacyEntry.outcomeKnownCount - (ledgerEntry?.outcomeKnownCount ?? 0), 0)
+            let success = max(legacyEntry.successCount - (ledgerEntry?.successCount ?? 0), 0)
+            let durationSamples = max(legacyEntry.durationSampleCount - (ledgerEntry?.durationSampleCount ?? 0), 0)
+            let durationMs = max(legacyEntry.durationMsTotal - (ledgerEntry?.durationMsTotal ?? 0), 0)
+            if count == 0, outcomeKnown == 0, success == 0, durationSamples == 0, durationMs == 0 {
+                continue
+            }
+            residual.append(CallAnalyticsEntry(
+                source: legacyEntry.source,
+                kind: legacyEntry.kind,
+                name: legacyEntry.name,
+                server: legacyEntry.server,
+                agent: legacyEntry.agent,
+                dayKey: legacyEntry.dayKey,
+                count: count,
+                outcomeKnownCount: outcomeKnown,
+                successCount: success,
+                durationSampleCount: durationSamples,
+                durationMsTotal: durationMs
+            ))
+        }
+        return residual
     }
 
     /// agentInvocations 跨日聚合键。

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -94,6 +94,10 @@ public actor CallAnalyticsEngine {
 
         // 展示组装：Claude/Codex 从归档（删 session 后过去日仍在，今天随实时刷新）；
         // OpenCode 从账本聚合（含补采回的历史日，且删 session 不丢账）。
+        // 旧归档 OpenCode 去重：账本完成全量回填后，旧归档的 OpenCode 条目按「日」让位账本
+        // （账本优先，避免与首次回填重复）；账本未回填的日（删会话独有）保留旧归档 OpenCode。
+        let ledgerOpenCodeDayKeys = Set(opencodeEntries.map { $0.dayKey })
+        let ledgerFullyImported = opencodeLedger.fullHistoryImported
         let lowerKey = cutoff.map { clock.dayKey($0) }
         let upperKey = end.map { clock.dayKey($0) }
         var entries: [CallAnalyticsEntry] = []
@@ -101,7 +105,13 @@ public actor CallAnalyticsEngine {
         for (day, bucket) in frozenDays {
             if let lowerKey, day < lowerKey { continue }
             if let upperKey, day > upperKey { continue }
-            entries.append(contentsOf: bucket.entries)
+            let deduped = Self.deduplicateLegacyOpenCode(
+                entries: bucket.entries,
+                day: day,
+                ledgerFullyImported: ledgerFullyImported,
+                ledgerOpenCodeDayKeys: ledgerOpenCodeDayKeys
+            )
+            entries.append(contentsOf: deduped)
             for inv in bucket.agentInvocations {
                 agentTotals[AgentInvocationKey(source: inv.source, agent: inv.agent), default: 0] += inv.count
             }
@@ -166,6 +176,19 @@ public actor CallAnalyticsEngine {
             return lastScan.addingTimeInterval(-overlap)
         }
         return fallbackCutoff
+    }
+
+    /// 旧归档 OpenCode 条目去重：账本完成全量回填后，旧归档中与账本聚合重叠的 OpenCode 条目
+    /// 让位账本（避免与首次回填双计）；账本未回填的日（删会话独有）保留旧归档 OpenCode。
+    /// internal（非 private）以便单元测试验证去重规则。
+    static func deduplicateLegacyOpenCode(
+        entries: [CallAnalyticsEntry],
+        day: String,
+        ledgerFullyImported: Bool,
+        ledgerOpenCodeDayKeys: Set<String>
+    ) -> [CallAnalyticsEntry] {
+        guard ledgerFullyImported, ledgerOpenCodeDayKeys.contains(day) else { return entries }
+        return entries.filter { $0.source != .opencode }
     }
 
     /// agentInvocations 跨日聚合键。

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/CallAnalyticsEngine.swift
@@ -48,38 +48,52 @@ public actor CallAnalyticsEngine {
         let openCodeServers = Set(installedMCP.filter { $0.source == .opencode }.map(\.name))
 
         // 首次：扫全历史以冻结所有过去日（之后只扫请求窗口即可，省 IO）。
-        // OpenCode 明细账本与日聚合归档是两套独立的全量导入标记：老用户 archive 可能已完成
-        // 导入，但新增的 opencode 账本尚未全量回填历史，此时仍需全量扫描，否则账本缺历史明细。
-        let needsFullImport = !archive.fullHistoryImported || !opencodeLedger.fullHistoryImported
-        let scanCutoff: Date? = needsFullImport ? nil : cutoff
+        // OpenCode 明细账本与日聚合归档是两套独立的全量导入标记，scan cutoff 也分开计算：
+        // - Claude/Codex 按 archive 自身的全量标记决定是否全量；
+        // - opencode 账本未全量时也全量；已全量则从上次成功扫描游标带安全重叠补采
+        //   （不能固定只扫今天，否则 23:xx 产生、00:xx 才首次同步的调用永久漏掉）。
+        //   两者互不影响，避免因 opencode 一直无法全量（如未安装）导致 Claude/Codex 每轮全量扫。
+        let archiveNeedsFullImport = !archive.fullHistoryImported
+        let ledgerNeedsFullImport = !opencodeLedger.fullHistoryImported
+        let nonOpenCodeScanCutoff: Date? = archiveNeedsFullImport ? nil : cutoff
+        let openCodeScanCutoff = Self.openCodeScanCutoff(
+            ledgerNeedsFullImport: ledgerNeedsFullImport,
+            lastSuccessfulScanDate: opencodeLedger.lastSuccessfulScanDate,
+            fallbackCutoff: cutoff
+        )
 
         let claude = ClaudeCallEventSource(homeDirectory: homeDirectory, timeZone: timeZone, environment: environment)
-            .collect(cutoff: scanCutoff)
+            .collect(cutoff: nonOpenCodeScanCutoff)
         let codex = CodexCallEventSource(homeDirectory: homeDirectory, timeZone: timeZone, environment: environment)
-            .collect(cutoff: scanCutoff)
+            .collect(cutoff: nonOpenCodeScanCutoff)
         let opencodeRaw = OpenCodeCallEventSource(
             homeDirectory: homeDirectory, timeZone: timeZone, environment: environment,
             knownMCPServers: openCodeServers
-        ).collect(cutoff: scanCutoff)
+        ).collect(cutoff: openCodeScanCutoff)
 
         // OpenCode 明细账本：issue #67 调用分析部分。按 part.id upsert、读不到的不删，
         // 使删除 opencode 会话后已记录的调用明细不丢；再从账本聚合回计数条目。
-        let opencodeLedgerEntries = opencodeLedger.merge(newEntries: opencodeRaw.entries, completedFullHistory: needsFullImport)
+        // 只有本次扫描成功（DB 快照创建+查询+解析全成功）才推进游标与全量标记，
+        // 失败或目录不可用保留原状态下次重试。
+        let openCodeScanSucceeded = opencodeRaw.status.available && opencodeRaw.status.errorCode == nil
+        let opencodeLedgerEntries = opencodeLedger.merge(newEntries: opencodeRaw.entries, scanSucceeded: openCodeScanSucceeded)
         let opencodeEntries = OpenCodeCallLedgerStore.aggregate(opencodeLedgerEntries)
 
-        // 实时结果按日分桶（entries 自带 dayKey；Claude 的 agentInvocations 已按天归属）。
-        var computed: [String: CallAnalyticsDayBucket] = [:]
-        for entry in claude.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
-        for entry in codex.entries { computed[entry.dayKey, default: .empty].entries.append(entry) }
-        for entry in opencodeEntries { computed[entry.dayKey, default: .empty].entries.append(entry) }
+        // 实时结果按日分桶：Claude/Codex 走归档冻结（无明细账本，删 session 靠归档保历史）；
+        // OpenCode 的过去日直接从账本聚合取——账本可补采历史日，而归档的「过去日首写冻结」
+        // 会阻止补采后的展示更新，故不把 OpenCode 条目塞进 archive 冻结。
+        var nonOpenCodeComputed: [String: CallAnalyticsDayBucket] = [:]
+        for entry in claude.entries { nonOpenCodeComputed[entry.dayKey, default: .empty].entries.append(entry) }
+        for entry in codex.entries { nonOpenCodeComputed[entry.dayKey, default: .empty].entries.append(entry) }
         for (day, invs) in claude.agentInvocationsByDay {
-            computed[day, default: .empty].agentInvocations.append(contentsOf: invs)
+            nonOpenCodeComputed[day, default: .empty].agentInvocations.append(contentsOf: invs)
         }
 
-        // 冻结合并 → 拿回全量归档日（含被删 session 的历史日）。
-        let frozenDays = archive.freeze(computed: computed, todayKey: todayKey, completedFullHistory: needsFullImport)
+        // 冻结 Claude/Codex → 拿回全量归档日（含被删 session 的历史日）。
+        let frozenDays = archive.freeze(computed: nonOpenCodeComputed, todayKey: todayKey, completedFullHistory: archiveNeedsFullImport)
 
-        // 从归档取请求范围内的数据展示：删 session 后过去日仍在，今天随实时刷新。
+        // 展示组装：Claude/Codex 从归档（删 session 后过去日仍在，今天随实时刷新）；
+        // OpenCode 从账本聚合（含补采回的历史日，且删 session 不丢账）。
         let lowerKey = cutoff.map { clock.dayKey($0) }
         let upperKey = end.map { clock.dayKey($0) }
         var entries: [CallAnalyticsEntry] = []
@@ -91,6 +105,11 @@ public actor CallAnalyticsEngine {
             for inv in bucket.agentInvocations {
                 agentTotals[AgentInvocationKey(source: inv.source, agent: inv.agent), default: 0] += inv.count
             }
+        }
+        for entry in opencodeEntries {
+            if let lowerKey, entry.dayKey < lowerKey { continue }
+            if let upperKey, entry.dayKey > upperKey { continue }
+            entries.append(entry)
         }
         let agentInvocations = agentTotals.map {
             AgentInvocationCount(source: $0.key.source, agent: $0.key.agent, count: $0.value)
@@ -129,6 +148,24 @@ public actor CallAnalyticsEngine {
         let clock = CallAnalyticsClock(timeZone: timeZone)
         let todayStart = clock.calendar.startOfDay(for: Date())
         _ = computeSnapshot(rangeKey: "today", cutoff: todayStart, end: nil)
+    }
+
+    /// OpenCode 源的扫描下限：未完成全量 → nil（扫全历史）；已完成 → 从上次成功扫描
+    /// 游标带 24h 安全重叠向前补采（覆盖跨日边界漏采）；旧账本无游标时退回请求窗口下限。
+    /// internal（非 private）以便单元测试直接验证补采窗口计算。
+    static func openCodeScanCutoff(
+        ledgerNeedsFullImport: Bool,
+        lastSuccessfulScanDate: Date?,
+        fallbackCutoff: Date?
+    ) -> Date? {
+        if ledgerNeedsFullImport {
+            return nil
+        }
+        if let lastScan = lastSuccessfulScanDate {
+            let overlap: TimeInterval = 24 * 3600
+            return lastScan.addingTimeInterval(-overlap)
+        }
+        return fallbackCutoff
     }
 
     /// agentInvocations 跨日聚合键。

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallEventSource.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallEventSource.swift
@@ -25,7 +25,7 @@ struct OpenCodeCallEventSource {
         "list", "webfetch", "patch", "task", "question", "todowrite", "todoread", "invalid"
     ]
 
-    func collect(cutoff: Date?) -> (entries: [CallAnalyticsEntry], status: CallSourceStatus) {
+    func collect(cutoff: Date?) -> (entries: [OpenCodeCallLedgerEntry], status: CallSourceStatus) {
         let clock = CallAnalyticsClock(timeZone: timeZone)
         guard let dataDirectory = resolveDataDirectory() else {
             return ([], CallSourceStatus(source: .opencode, available: false, eventCount: 0, filesScanned: 0, errorCode: nil))
@@ -41,10 +41,12 @@ struct OpenCodeCallEventSource {
         defer { cleanupDatabaseSnapshot(snapshotPath) }
 
         let sinceMillis: Int64? = cutoff.map { Int64($0.timeIntervalSince1970 * 1000) }
-        var accumulator = CallEventAccumulator()
+        var entries: [OpenCodeCallLedgerEntry] = []
         do {
-            try forEachToolPart(databasePath: snapshotPath, sinceMillis: sinceMillis) { millis, data in
-                parsePart(data, millis: millis, clock: clock, into: &accumulator)
+            try forEachToolPart(databasePath: snapshotPath, sinceMillis: sinceMillis) { partId, millis, data in
+                if let entry = parsePart(partId: partId, data, millis: millis, clock: clock) {
+                    entries.append(entry)
+                }
             }
         } catch {
             let code = (error as? ProviderError)?.code ?? "db_query_failed"
@@ -54,38 +56,38 @@ struct OpenCodeCallEventSource {
         let status = CallSourceStatus(
             source: .opencode,
             available: true,
-            eventCount: accumulator.eventCount,
+            eventCount: entries.count,
             filesScanned: 1,
             errorCode: nil
         )
-        return (accumulator.entries(), status)
+        return (entries, status)
     }
 
     // MARK: - Parsing
 
     private func parsePart(
+        partId: String,
         _ data: Data,
         millis: Int64,
-        clock: CallAnalyticsClock,
-        into accumulator: inout CallEventAccumulator
-    ) {
+        clock: CallAnalyticsClock
+    ) -> OpenCodeCallLedgerEntry? {
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               (object["type"] as? String) == "tool",
               let tool = (object["tool"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
               !tool.isEmpty else {
-            return
+            return nil
         }
         let dayKey = clock.dayKey(fromMillis: millis)
         let state = object["state"] as? [String: Any]
-        classify(tool: tool, state: state, dayKey: dayKey, into: &accumulator)
+        return classify(partId: partId, tool: tool, state: state, dayKey: dayKey)
     }
 
     private func classify(
+        partId: String,
         tool: String,
         state: [String: Any]?,
-        dayKey: String,
-        into accumulator: inout CallEventAccumulator
-    ) {
+        dayKey: String
+    ) -> OpenCodeCallLedgerEntry {
         let lower = tool.lowercased()
         // OpenCode 每条 tool part 自带 status 与 time，故成功率/耗时对所有类别（MCP/技能/工具）通用。
         let success = Self.outcome(from: state)
@@ -95,30 +97,25 @@ struct OpenCodeCallEventSource {
             let input = state?["input"] as? [String: Any]
             let raw = (input?["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let skillName = raw.isEmpty ? "(unknown)" : raw
-            accumulator.add(source: .opencode, kind: .skill, name: skillName, server: nil, dayKey: dayKey,
-                            success: success, durationMs: durationMs)
-            return
+            return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: .skill, name: skillName, server: nil, success: success, durationMs: durationMs)
         }
 
         if Self.builtinTools.contains(lower) {
             let kind: CallKind = lower == "webfetch" ? .webSearch : .builtin
-            accumulator.add(source: .opencode, kind: kind, name: tool, server: nil, dayKey: dayKey,
-                            success: success, durationMs: durationMs)
-            return
+            return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: kind, name: tool, server: nil, success: success, durationMs: durationMs)
         }
 
         // 优先用已装 server 名做最长前缀匹配（server 名本身含 `_`/`-` 时切分才准），匹配不到再回退。
         if let match = matchKnownServer(tool: tool) {
-            accumulator.add(
-                source: .opencode,
+            return OpenCodeCallLedgerEntry(
+                partId: partId,
+                dayKey: dayKey,
                 kind: .mcp,
                 name: CallAnalyticsNaming.mcpDisplayName(server: match.server, tool: match.tool),
                 server: match.server,
-                dayKey: dayKey,
                 success: success,
                 durationMs: durationMs
             )
-            return
         }
 
         // 回退启发式：OpenCode 把 MCP 工具命名为 `<server>_<tool>`；非内置且含下划线者归为 MCP。
@@ -126,21 +123,19 @@ struct OpenCodeCallEventSource {
             let server = String(tool[tool.startIndex..<sep])
             let toolName = String(tool[tool.index(after: sep)...])
             if !server.isEmpty, !toolName.isEmpty {
-                accumulator.add(
-                    source: .opencode,
+                return OpenCodeCallLedgerEntry(
+                    partId: partId,
+                    dayKey: dayKey,
                     kind: .mcp,
                     name: CallAnalyticsNaming.mcpDisplayName(server: server, tool: toolName),
                     server: server,
-                    dayKey: dayKey,
                     success: success,
                     durationMs: durationMs
                 )
-                return
             }
         }
 
-        accumulator.add(source: .opencode, kind: .other, name: tool, server: nil, dayKey: dayKey,
-                        success: success, durationMs: durationMs)
+        return OpenCodeCallLedgerEntry(partId: partId, dayKey: dayKey, kind: .other, name: tool, server: nil, success: success, durationMs: durationMs)
     }
 
     /// 从 part.state 判定成功/失败：completed→成功，error→失败，其余（pending/running 等）→nil（不计入分母）。
@@ -217,7 +212,7 @@ struct OpenCodeCallEventSource {
     private func forEachToolPart(
         databasePath: String,
         sinceMillis: Int64?,
-        onRow: (Int64, Data) -> Void
+        onRow: (String, Int64, Data) -> Void
     ) throws {
         var db: OpaquePointer?
         guard sqlite3_open_v2(databasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
@@ -227,7 +222,7 @@ struct OpenCodeCallEventSource {
         }
         defer { sqlite3_close(db) }
 
-        var sql = "SELECT time_created, data FROM part WHERE data LIKE '%\"type\":\"tool\"%'"
+        var sql = "SELECT id, time_created, data FROM part WHERE data LIKE '%\"type\":\"tool\"%'"
         if sinceMillis != nil {
             sql += " AND time_created >= ?"
         }
@@ -250,9 +245,11 @@ struct OpenCodeCallEventSource {
                 let message = String(cString: sqlite3_errmsg(db))
                 throw ProviderError("db_step_failed", SensitiveDataRedactor.redactPaths(in: message))
             }
-            guard let dataCString = sqlite3_column_text(statement, 1) else { continue }
-            let millis = sqlite3_column_int64(statement, 0)
-            onRow(millis, Data(String(cString: dataCString).utf8))
+            guard let idCString = sqlite3_column_text(statement, 0) else { continue }
+            let partId = String(cString: idCString)
+            let millis = sqlite3_column_int64(statement, 1)
+            guard let dataCString = sqlite3_column_text(statement, 2) else { continue }
+            onRow(partId, millis, Data(String(cString: dataCString).utf8))
         }
         openCodeCallLog.debug("OpenCode call-analytics scanned part rows")
     }

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
@@ -1,0 +1,191 @@
+import Foundation
+import os.log
+
+private let openCodeCallLedgerLog = Logger(subsystem: "com.aiusage.quotabackend", category: "OpenCodeCallLedger")
+
+// MARK: - OpenCode Call Ledger Store
+// 「调用分析」OpenCode 源的明细账本（issue #67 的调用分析部分）。
+// 解决「删除 opencode 会话后，工具/MCP/Skill 调用次数统计丢失」。
+//
+// 数据源：opencode.db 的 `part` 表。message 删除会对 part 做级联删除（onDelete: cascade），
+// 因此删 session 后 part 行消失，实时重扫拿不到 → 今天的调用次数减少。
+// 本账本把每条 tool part（按 `part.id`，即 `prt_xxx`）持久化，扫描时按 id upsert、
+// 读不到的不删，从而在 opencode 侧删会话后仍保留已记录的调用明细。
+//
+// 语义：
+// - 本次扫描读到的 part 按 `id` upsert（覆盖旧值，处理 part 状态从 running→completed 的更新）；
+// - 账本里本次读不到的 part 不删（处理「删除会话」不丢账）；
+// - 首次启动做一次「全量历史导入」（completedFullHistory 标记），之后只扫请求窗口。
+//
+// 聚合：`aggregate` 把明细条目还原为「日 × 类别 × 名称(× server)」的 CallAnalyticsEntry，
+// 与实时 CallEventAccumulator 口径一致（count / outcomeKnownCount / successCount /
+// durationSampleCount / durationMsTotal）。
+//
+// 持久化（永久，放 ~/.config/aiusage 避免被系统磁盘清理）:
+//   <home>/.config/aiusage/usage-archive/opencode-call-ledger-v<version>.json
+//
+// 线程：本类仅由 CallAnalyticsEngine（actor）持有并访问，访问被引擎 actor 串行化，
+// 故与 CallAnalyticsArchiveStore 一样无需自身加锁。
+
+/// 一条 OpenCode 工具调用明细（对应 part 表的一行 tool part）。
+struct OpenCodeCallLedgerEntry: Codable, Sendable, Equatable {
+    /// part 表主键（`prt_xxx`），稳定唯一去重键。
+    let partId: String
+    /// yyyy-MM-dd（本地时区），由 part.time_created 派生。
+    let dayKey: String
+    /// 调用类别（mcp / skill / builtin / webSearch / other）。
+    let kind: CallKind
+    /// 展示名：MCP=`server/tool`，Skill=技能名，其它=工具名。
+    let name: String
+    /// 仅 MCP 有值。
+    let server: String?
+    /// 成功/失败（nil = 无结果信号，如 pending/running）。
+    let success: Bool?
+    /// 耗时（毫秒），缺失或非法为 nil。
+    let durationMs: Double?
+}
+
+/// 账本文件结构。
+struct OpenCodeCallLedger: Codable, Sendable {
+    let version: Int
+    var updatedAt: String
+    var entries: [String: OpenCodeCallLedgerEntry]
+    var fullHistoryImportedAt: String?
+}
+
+final class OpenCodeCallLedgerStore {
+    static let artifactVersion = 1
+
+    private let homeDirectory: String
+    private var cached: OpenCodeCallLedger?
+
+    init(homeDirectory: String) {
+        self.homeDirectory = homeDirectory
+    }
+
+    /// 是否已完成全量历史导入。false → 引擎应先扫全历史以冻结所有过去日。
+    var fullHistoryImported: Bool {
+        load().fullHistoryImportedAt != nil
+    }
+
+    /// 合并本次扫描到的明细：按 partId upsert，账本里读不到的不删。
+    /// `completedFullHistory` 为 true 时无条件标记全量导入完成（即使本次为空，也避免重复全量扫描）。
+    /// 返回合并后的全部明细（含被删除会话的历史）。
+    @discardableResult
+    func merge(newEntries: [OpenCodeCallLedgerEntry], completedFullHistory: Bool) -> [OpenCodeCallLedgerEntry] {
+        var ledger = load()
+        var changed = false
+
+        for entry in newEntries {
+            if ledger.entries[entry.partId] != entry {
+                ledger.entries[entry.partId] = entry
+                changed = true
+            }
+        }
+
+        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
+            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+            changed = true
+        }
+
+        if changed {
+            ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+            cached = ledger
+            save(ledger)
+        } else {
+            cached = ledger
+        }
+        return Array(ledger.entries.values)
+    }
+
+    /// 账本全部明细（含被删除会话的历史）。
+    func allEntries() -> [OpenCodeCallLedgerEntry] {
+        Array(load().entries.values)
+    }
+
+    /// 把明细条目聚合为「日 × 类别 × 名称(× server)」的计数条目，口径与实时 CallEventAccumulator 一致。
+    static func aggregate(_ entries: [OpenCodeCallLedgerEntry]) -> [CallAnalyticsEntry] {
+        struct Key: Hashable {
+            let kind: CallKind
+            let name: String
+            let server: String?
+            let dayKey: String
+        }
+        struct Agg {
+            var count = 0
+            var outcomeKnown = 0
+            var success = 0
+            var durationSamples = 0
+            var durationMsTotal = 0.0
+        }
+
+        var counts: [Key: Agg] = [:]
+        for entry in entries {
+            let key = Key(kind: entry.kind, name: entry.name, server: entry.server, dayKey: entry.dayKey)
+            var agg = counts[key] ?? Agg()
+            agg.count += 1
+            if let success = entry.success {
+                agg.outcomeKnown += 1
+                if success { agg.success += 1 }
+            }
+            if let durationMs = entry.durationMs, durationMs >= 0 {
+                agg.durationSamples += 1
+                agg.durationMsTotal += durationMs
+            }
+            counts[key] = agg
+        }
+
+        return counts.map { key, agg in
+            CallAnalyticsEntry(
+                source: .opencode,
+                kind: key.kind,
+                name: key.name,
+                server: key.server,
+                agent: nil,
+                dayKey: key.dayKey,
+                count: agg.count,
+                outcomeKnownCount: agg.outcomeKnown,
+                successCount: agg.success,
+                durationSampleCount: agg.durationSamples,
+                durationMsTotal: agg.durationMsTotal
+            )
+        }
+    }
+
+    // MARK: - Disk
+
+    private func load() -> OpenCodeCallLedger {
+        if let cached { return cached }
+
+        if let data = try? Data(contentsOf: Self.fileURL(homeDirectory: homeDirectory)),
+           let decoded = try? JSONDecoder().decode(OpenCodeCallLedger.self, from: data),
+           decoded.version == Self.artifactVersion {
+            cached = decoded
+            return decoded
+        }
+
+        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil)
+        cached = fresh
+        return fresh
+    }
+
+    private func save(_ ledger: OpenCodeCallLedger) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(ledger)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            openCodeCallLedgerLog.warning("Failed to save opencode call ledger: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    static func fileURL(homeDirectory: String) -> URL {
+        let dir = (homeDirectory as NSString).appendingPathComponent(".config/aiusage/usage-archive")
+        return URL(fileURLWithPath: dir, isDirectory: true)
+            .appendingPathComponent("opencode-call-ledger-v\(artifactVersion).json")
+    }
+}

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
@@ -57,10 +57,15 @@ struct OpenCodeCallLedger: Codable, Sendable {
     /// 而不是固定扫「今天」，从而补回跨日漏采（如 23:xx 产生、00:xx 才首次同步的调用）。
     /// nil = 尚未成功扫描过（或旧账本无此字段），需回退到全量或请求窗口。
     var lastSuccessfulScanMillis: Int64?
+    /// 旧调用归档迁移后的「残差」（max(旧归档 - 迁移时账本聚合, 0)，聚合后条目冻结）。
+    /// 迁移后展示恒为「当前账本 + 残差」，完全重叠不重复、完全删除不丢、同日部分删除也不丢。nil = 尚未迁移。
+    var legacyResidualEntries: [CallAnalyticsEntry]?
+    /// 旧调用归档迁移完成时间（ISO8601）。nil = 尚未迁移。
+    var legacyArchiveMigratedAt: String?
 }
 
 final class OpenCodeCallLedgerStore {
-    static let artifactVersion = 1
+    static let artifactVersion = 2
 
     private let homeDirectory: String
     private var cached: OpenCodeCallLedger?
@@ -78,6 +83,16 @@ final class OpenCodeCallLedgerStore {
     var lastSuccessfulScanDate: Date? {
         guard let millis = load().lastSuccessfulScanMillis else { return nil }
         return Date(timeIntervalSince1970: Double(millis) / 1000)
+    }
+
+    /// 旧调用归档是否已迁移完成。
+    var legacyArchiveMigrated: Bool {
+        load().legacyArchiveMigratedAt != nil
+    }
+
+    /// 已迁入的旧调用归档残差（聚合后条目冻结）。迁移后叠加到账本聚合之上展示。
+    var legacyResidual: [CallAnalyticsEntry] {
+        load().legacyResidualEntries ?? []
     }
 
     /// 合并本次扫描到的明细：按 partId upsert，账本里读不到的不删。
@@ -172,6 +187,18 @@ final class OpenCodeCallLedgerStore {
         }
     }
 
+    /// 一次性把旧调用归档的残差写入账本（幂等）。迁移完成后旧归档的 OpenCode 条目不再参与展示，
+    /// 改由「当前账本 + 残差」承担；后续新调用继续由账本正常增量。
+    func migrateLegacyResidual(_ entries: [CallAnalyticsEntry]) {
+        var ledger = load()
+        guard ledger.legacyArchiveMigratedAt == nil else { return }
+        ledger.legacyResidualEntries = entries
+        ledger.legacyArchiveMigratedAt = SharedFormatters.iso8601String(from: Date())
+        ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+        cached = ledger
+        save(ledger)
+    }
+
     // MARK: - Disk
 
     private func load() -> OpenCodeCallLedger {
@@ -184,7 +211,7 @@ final class OpenCodeCallLedgerStore {
             return decoded
         }
 
-        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil, lastSuccessfulScanMillis: nil)
+        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil, lastSuccessfulScanMillis: nil, legacyResidualEntries: nil, legacyArchiveMigratedAt: nil)
         cached = fresh
         return fresh
     }

--- a/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/CallAnalytics/OpenCodeCallLedgerStore.swift
@@ -15,7 +15,9 @@ private let openCodeCallLedgerLog = Logger(subsystem: "com.aiusage.quotabackend"
 // 语义：
 // - 本次扫描读到的 part 按 `id` upsert（覆盖旧值，处理 part 状态从 running→completed 的更新）；
 // - 账本里本次读不到的 part 不删（处理「删除会话」不丢账）；
-// - 首次启动做一次「全量历史导入」（completedFullHistory 标记），之后只扫请求窗口。
+// - 首次启动做一次「全量历史导入」（fullHistoryImportedAt 标记），之后从
+//   lastSuccessfulScanMillis 游标带安全重叠补采，而不是固定只扫今天；
+// - 只有本次 DB 快照创建、查询、解析全成功（scanSucceeded）才推进游标与全量标记。
 //
 // 聚合：`aggregate` 把明细条目还原为「日 × 类别 × 名称(× server)」的 CallAnalyticsEntry，
 // 与实时 CallEventAccumulator 口径一致（count / outcomeKnownCount / successCount /
@@ -51,6 +53,10 @@ struct OpenCodeCallLedger: Codable, Sendable {
     var updatedAt: String
     var entries: [String: OpenCodeCallLedgerEntry]
     var fullHistoryImportedAt: String?
+    /// 最后一次成功扫描时间（epoch 毫秒）。作为增量补采游标：下次从该位置带安全重叠向前扫，
+    /// 而不是固定扫「今天」，从而补回跨日漏采（如 23:xx 产生、00:xx 才首次同步的调用）。
+    /// nil = 尚未成功扫描过（或旧账本无此字段），需回退到全量或请求窗口。
+    var lastSuccessfulScanMillis: Int64?
 }
 
 final class OpenCodeCallLedgerStore {
@@ -68,11 +74,18 @@ final class OpenCodeCallLedgerStore {
         load().fullHistoryImportedAt != nil
     }
 
+    /// 最后一次成功扫描时间。nil = 尚未成功扫描过。
+    var lastSuccessfulScanDate: Date? {
+        guard let millis = load().lastSuccessfulScanMillis else { return nil }
+        return Date(timeIntervalSince1970: Double(millis) / 1000)
+    }
+
     /// 合并本次扫描到的明细：按 partId upsert，账本里读不到的不删。
-    /// `completedFullHistory` 为 true 时无条件标记全量导入完成（即使本次为空，也避免重复全量扫描）。
+    /// `scanSucceeded` 为 true 时才推进「全量导入完成」标记与补采游标；
+    /// 失败（DB 快照/查询失败、目录不可用）保留原状态，下次重试。
     /// 返回合并后的全部明细（含被删除会话的历史）。
     @discardableResult
-    func merge(newEntries: [OpenCodeCallLedgerEntry], completedFullHistory: Bool) -> [OpenCodeCallLedgerEntry] {
+    func merge(newEntries: [OpenCodeCallLedgerEntry], scanSucceeded: Bool) -> [OpenCodeCallLedgerEntry] {
         var ledger = load()
         var changed = false
 
@@ -83,9 +96,16 @@ final class OpenCodeCallLedgerStore {
             }
         }
 
-        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
-            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
-            changed = true
+        if scanSucceeded {
+            if ledger.fullHistoryImportedAt == nil {
+                ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+                changed = true
+            }
+            let nowMillis = Int64(Date().timeIntervalSince1970 * 1000)
+            if ledger.lastSuccessfulScanMillis != nowMillis {
+                ledger.lastSuccessfulScanMillis = nowMillis
+                changed = true
+            }
         }
 
         if changed {
@@ -164,7 +184,7 @@ final class OpenCodeCallLedgerStore {
             return decoded
         }
 
-        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil)
+        let fresh = OpenCodeCallLedger(version: Self.artifactVersion, updatedAt: "", entries: [:], fullHistoryImportedAt: nil, lastSuccessfulScanMillis: nil)
         cached = fresh
         return fresh
     }

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Aggregation.swift
@@ -37,15 +37,6 @@ extension OpenCodeCostProvider {
 
     // MARK: Aggregation
 
-    /// rows → 按日聚合桶。
-    func buildDays(rows: [CodexRow]) -> [String: CodexAggregateBucket] {
-        var days: [String: CodexAggregateBucket] = [:]
-        for row in rows {
-            days[row.dayKey, default: .empty].record(row: row)
-        }
-        return days
-    }
-
     func aggregateDays(
         _ bucketsByDay: [String: CodexAggregateBucket],
         matching: (String) -> Bool

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Database.swift
@@ -13,6 +13,7 @@ extension OpenCodeCostProvider {
 
     /// message 表的一行原始数据（data 为 OpenCode 的消息 JSON）。
     struct MessageRow: Sendable {
+        let messageId: String
         let sessionId: String
         let timeCreatedMillis: Int64
         let data: Data
@@ -28,7 +29,7 @@ extension OpenCodeCostProvider {
         }
         defer { sqlite3_close(db) }
 
-        var sql = "SELECT session_id, time_created, data FROM message"
+        var sql = "SELECT id, session_id, time_created, data FROM message"
         if sinceMillis != nil {
             sql += " WHERE time_created >= ?"
         }
@@ -53,13 +54,15 @@ extension OpenCodeCostProvider {
                 throw ProviderError("db_step_failed", SensitiveDataRedactor.redactPaths(in: message))
             }
 
-            guard let sessionCString = sqlite3_column_text(statement, 0),
-                  let dataCString = sqlite3_column_text(statement, 2) else {
+            guard let idCString = sqlite3_column_text(statement, 0),
+                  let sessionCString = sqlite3_column_text(statement, 1),
+                  let dataCString = sqlite3_column_text(statement, 3) else {
                 continue
             }
             rows.append(MessageRow(
+                messageId: String(cString: idCString),
                 sessionId: String(cString: sessionCString),
-                timeCreatedMillis: sqlite3_column_int64(statement, 1),
+                timeCreatedMillis: sqlite3_column_int64(statement, 2),
                 data: Data(String(cString: dataCString).utf8)
             ))
         }

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider+Parsing.swift
@@ -41,9 +41,10 @@ extension OpenCodeCostProvider {
     /// 这里排除以免在 OpenCode 用量/费用/热力图里被重复计数。per-node 受管键恒为 `aiusage-<slug>`，不受影响。
     static let globalProxyProviderID = "aiusage"
 
-    /// 解析一行 message；非 assistant、零用量或无法解码的行返回 nil。
+    /// 解析一行 message 为账本明细条目；非 assistant、零用量或无法解码的行返回 nil。
+    /// 保留 messageId/sessionId/timeCreatedMillis 用于增量账本去重与明细追溯（issue #67）。
     /// decoder 由调用方每次 fetch 创建一只并复用（避免逐行新建，也避免跨任务共享）。
-    func parseMessageRow(_ row: MessageRow, decoder: JSONDecoder) -> CodexRow? {
+    func parseLedgerEntry(_ row: MessageRow, decoder: JSONDecoder) -> OpenCodeLedgerEntry? {
         guard let message = try? decoder.decode(MessageData.self, from: row.data),
               message.role == "assistant" else {
             return nil
@@ -63,13 +64,16 @@ extension OpenCodeCostProvider {
         guard totalTokens > 0 || cost > 0 else { return nil }
 
         let createdAt = Date(timeIntervalSince1970: Double(row.timeCreatedMillis) / 1000)
-        return CodexRow(
+        return OpenCodeLedgerEntry(
+            messageId: row.messageId,
+            sessionId: row.sessionId,
+            timeCreatedMillis: row.timeCreatedMillis,
             dayKey: dayKey(createdAt),
             model: modelLabel(providerID: message.providerID, modelID: message.modelID),
             inputTokens: inputTokens,
+            outputTokens: outputTokens,
             cacheReadTokens: cacheReadTokens,
             cacheCreateTokens: cacheCreateTokens,
-            outputTokens: outputTokens,
             totalTokens: totalTokens,
             estimatedCostUsd: cost
         )

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -51,23 +51,29 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         )
 
         // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/快照失败时不推进账本游标，下次重试）。
+        //    扫描错误暂存到 scanError，不在有可用旧归档时提前退出（迁移 pending 时旧归档仍要回退展示）。
+        var scanError: Error?
         let dataDirectory = resolveDataDirectory()
         if let dataDirectory {
-            let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
-            defer { cleanupDatabaseSnapshot(snapshotPath) }
-            let messageRows = try fetchMessageRows(databasePath: snapshotPath, sinceMillis: sinceMillis)
-            let decoder = JSONDecoder()
-            var entries: [OpenCodeLedgerEntry] = []
-            entries.reserveCapacity(messageRows.count)
-            for messageRow in messageRows {
-                guard let entry = parseLedgerEntry(messageRow, decoder: decoder) else { continue }
-                entries.append(entry)
+            do {
+                let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
+                defer { cleanupDatabaseSnapshot(snapshotPath) }
+                let messageRows = try fetchMessageRows(databasePath: snapshotPath, sinceMillis: sinceMillis)
+                let decoder = JSONDecoder()
+                var entries: [OpenCodeLedgerEntry] = []
+                entries.reserveCapacity(messageRows.count)
+                for messageRow in messageRows {
+                    guard let entry = parseLedgerEntry(messageRow, decoder: decoder) else { continue }
+                    entries.append(entry)
+                }
+                await Self.ledger.merge(
+                    homeDirectory: homeDirectory,
+                    newEntries: entries,
+                    scanSucceeded: true
+                )
+            } catch {
+                scanError = error
             }
-            await Self.ledger.merge(
-                homeDirectory: homeDirectory,
-                newEntries: entries,
-                scanSucceeded: true
-            )
         }
         relieveMallocPressure()
 
@@ -110,6 +116,11 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         //    即使本地 db 为空，只要有代理用量也照常呈现。
         let days = mergeProxyDays(into: mergedDays)
         guard !days.isEmpty else {
+            // 旧归档也为空时优先抛原始扫描错误（不伪装成成功或 no_usage_data）；
+            // 有旧归档回退时上面已正常返回，不会走到这里。
+            if let scanError {
+                throw scanError
+            }
             throw ProviderError("no_usage_data", "No OpenCode usage recorded (opencode.db not found or empty; requires OpenCode >= 1.2)")
         }
 

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -20,8 +20,11 @@ public struct OpenCodeCostProvider: ProviderFetcher {
     let environment: [String: String]
 
     /// 独立明细账本（message 级，按 message.id 去重增量），issue #67 的持久真相源。
-    /// 展示层直接用账本聚合，旧的 OpenCodeUsageArchiveStore 日归档已退役（避免「过去日冻结」阻止补采更新）。
+    /// 展示层用账本聚合 + 旧 usage-archive 一次性迁移的历史日（删会话独有），
+    /// 旧归档在迁移完成后退役（避免「过去日冻结」阻止补采更新）。
     static let ledger = OpenCodeLedgerStore()
+    /// 旧 usage-archive（升级前日归档），仅用于一次性迁移，迁移后退役。
+    static let archive = OpenCodeUsageArchiveStore()
     static let defaultScanDays = 30
 
     public init(
@@ -68,14 +71,28 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         }
         relieveMallocPressure()
 
-        // 2) 账本聚合直接作为展示源（账本即真相源，含补采回填的历史；不再走 archive 冻结避免旧值覆盖新账）。
+        // 2) 账本聚合作为展示源（账本即真相源，含补采回填的历史）。
         let ledgerEntries = await Self.ledger.allEntries(homeDirectory: homeDirectory)
         let sessionIds = Set(ledgerEntries.map { $0.sessionId })
         let dbDays = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
-        // 3) 合并全局统一代理用量（来自代理日志永久归档，模型键同口径 `aiusage-<slug>/<model>`，
+
+        // 3) 一次性把旧 usage-archive 的历史日迁入账本（幂等），迁移后旧归档退役：
+        //    删会话独有的历史日保留在 legacyDays，账本聚合覆盖重叠日（不双计）。
+        if await Self.ledger.needsLegacyArchiveMigration(homeDirectory: homeDirectory) {
+            let archiveDays = await Self.archive.days(homeDirectory: homeDirectory)
+            await Self.ledger.migrateLegacyArchiveIfNeeded(
+                homeDirectory: homeDirectory,
+                legacyDays: archiveDays,
+                todayKey: todayKey
+            )
+        }
+        let legacyDays = await Self.ledger.legacyDays(homeDirectory: homeDirectory)
+        let mergedDays = legacyDays.merging(dbDays) { _, ledger in ledger }
+
+        // 4) 合并全局统一代理用量（来自代理日志永久归档，模型键同口径 `aiusage-<slug>/<model>`，
         //    同节点同模型与 db 直连自动并入同一行；db 侧已排除裸全局 provider，两源互斥不双计）。
         //    即使本地 db 为空，只要有代理用量也照常呈现。
-        let days = mergeProxyDays(into: dbDays)
+        let days = mergeProxyDays(into: mergedDays)
         guard !days.isEmpty else {
             throw ProviderError("no_usage_data", "No OpenCode usage recorded (opencode.db not found or empty; requires OpenCode >= 1.2)")
         }

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -78,7 +78,6 @@ public struct OpenCodeCostProvider: ProviderFetcher {
 
         // 3) 一次性把旧 usage-archive 迁入账本为「残差」（幂等），迁移后旧归档退役。
         //    迁移前置：账本已完成全量历史导入（否则残差不完整）；残差 = max(旧归档 - 迁移时账本快照, 0)。
-        //    展示恒为「当前账本 + 残差」：完全重叠不重复、完全删除不丢、同日部分删除也不丢。
         if await Self.ledger.needsLegacyArchiveMigration(homeDirectory: homeDirectory),
            await Self.ledger.isFullHistoryImported(homeDirectory: homeDirectory) {
             let archiveDays = await Self.archive.days(homeDirectory: homeDirectory)
@@ -89,11 +88,21 @@ public struct OpenCodeCostProvider: ProviderFetcher {
                 todayKey: todayKey
             )
         }
-        let legacyResidualDays = await Self.ledger.legacyResidualDays(homeDirectory: homeDirectory)
-        let mergedDays = dbDays.merging(legacyResidualDays) { ledger, residual in
-            var merged = ledger
-            merged.merge(residual)
-            return merged
+        // 展示：迁移完成后恒为「账本 + 持久化残差」（完全重叠不重复、完全删除不丢、同日部分删除也不丢）；
+        //      迁移 pending（账本尚未完成全量回填，或数据目录暂不可用）时过去日回退原旧归档
+        //      （账本覆盖重叠日、删会话独有日保留），保证旧归档历史仍可见且迁移状态保持 pending。
+        let mergedDays: [String: CodexAggregateBucket]
+        if await Self.ledger.needsLegacyArchiveMigration(homeDirectory: homeDirectory) {
+            let archiveDays = await Self.archive.days(homeDirectory: homeDirectory)
+            let archivePastDays = archiveDays.filter { $0.key != todayKey }
+            mergedDays = archivePastDays.merging(dbDays) { _, ledger in ledger }
+        } else {
+            let legacyResidualDays = await Self.ledger.legacyResidualDays(homeDirectory: homeDirectory)
+            mergedDays = dbDays.merging(legacyResidualDays) { ledger, residual in
+                var merged = ledger
+                merged.merge(residual)
+                return merged
+            }
         }
 
         // 4) 合并全局统一代理用量（来自代理日志永久归档，模型键同口径 `aiusage-<slug>/<model>`，

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -76,18 +76,25 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         let sessionIds = Set(ledgerEntries.map { $0.sessionId })
         let dbDays = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
 
-        // 3) 一次性把旧 usage-archive 的历史日迁入账本（幂等），迁移后旧归档退役：
-        //    删会话独有的历史日保留在 legacyDays，账本聚合覆盖重叠日（不双计）。
-        if await Self.ledger.needsLegacyArchiveMigration(homeDirectory: homeDirectory) {
+        // 3) 一次性把旧 usage-archive 迁入账本为「残差」（幂等），迁移后旧归档退役。
+        //    迁移前置：账本已完成全量历史导入（否则残差不完整）；残差 = max(旧归档 - 迁移时账本快照, 0)。
+        //    展示恒为「当前账本 + 残差」：完全重叠不重复、完全删除不丢、同日部分删除也不丢。
+        if await Self.ledger.needsLegacyArchiveMigration(homeDirectory: homeDirectory),
+           await Self.ledger.isFullHistoryImported(homeDirectory: homeDirectory) {
             let archiveDays = await Self.archive.days(homeDirectory: homeDirectory)
             await Self.ledger.migrateLegacyArchiveIfNeeded(
                 homeDirectory: homeDirectory,
                 legacyDays: archiveDays,
+                ledgerSnapshotDays: dbDays,
                 todayKey: todayKey
             )
         }
-        let legacyDays = await Self.ledger.legacyDays(homeDirectory: homeDirectory)
-        let mergedDays = legacyDays.merging(dbDays) { _, ledger in ledger }
+        let legacyResidualDays = await Self.ledger.legacyResidualDays(homeDirectory: homeDirectory)
+        let mergedDays = dbDays.merging(legacyResidualDays) { ledger, residual in
+            var merged = ledger
+            merged.merge(residual)
+            return merged
+        }
 
         // 4) 合并全局统一代理用量（来自代理日志永久归档，模型键同口径 `aiusage-<slug>/<model>`，
         //    同节点同模型与 db 直连自动并入同一行；db 侧已排除裸全局 provider，两源互斥不双计）。

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -21,6 +21,8 @@ public struct OpenCodeCostProvider: ProviderFetcher {
 
     /// 永久每日归档（每个 home 一张，按 homeDirectory 区分以隔离测试 / 多配置）。
     static let archive = OpenCodeUsageArchiveStore()
+    /// 独立明细账本（message 级，按 message.id 去重增量），issue #67 的持久真相源。
+    static let ledger = OpenCodeLedgerStore()
     static let defaultScanDays = 30
 
     public init(
@@ -37,31 +39,35 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         let now = Date()
         let todayKey = dayKey(now)
 
-        // 首次（归档从未完成全量）触发全量扫描以冻结所有历史日；之后只扫窗口。
-        let shouldImportFullHistory = await Self.archive.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
+        // 首次（账本从未完成全量）触发全量扫描以回填账本全部明细；之后只扫窗口。
+        let shouldImportFullHistory = await Self.ledger.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
         let sinceMillis: Int64? = shouldImportFullHistory ? nil : scanWindowStartMillis(now: now)
 
-        // 1) 读库（OpenCode 未安装/版本过旧时跳过：冻结归档可能仍有历史数据）。
+        // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/版本过旧时跳过，账本仍有历史）。
         let dataDirectory = resolveDataDirectory()
-        var sessionIds = Set<String>()
-        var computed: [String: CodexAggregateBucket] = [:]
         if let dataDirectory {
             let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
             defer { cleanupDatabaseSnapshot(snapshotPath) }
             let messageRows = try fetchMessageRows(databasePath: snapshotPath, sinceMillis: sinceMillis)
             let decoder = JSONDecoder()
-            var rows: [CodexRow] = []
-            rows.reserveCapacity(messageRows.count)
+            var entries: [OpenCodeLedgerEntry] = []
+            entries.reserveCapacity(messageRows.count)
             for messageRow in messageRows {
-                guard let row = parseMessageRow(messageRow, decoder: decoder) else { continue }
-                rows.append(row)
-                sessionIds.insert(messageRow.sessionId)
+                guard let entry = parseLedgerEntry(messageRow, decoder: decoder) else { continue }
+                entries.append(entry)
             }
-            computed = buildDays(rows: rows)
+            await Self.ledger.merge(
+                homeDirectory: homeDirectory,
+                newEntries: entries,
+                completedFullHistory: shouldImportFullHistory
+            )
         }
         relieveMallocPressure()
 
-        // 2) 冻结归档：昨日前首写冻结、今天覆盖重算；删除本地库后历史不丢。
+        // 2) 账本聚合 → 冻结归档：昨日前首写冻结、今天从账本累积覆盖（删除会话后账本不删，统计不丢）。
+        let ledgerEntries = await Self.ledger.allEntries(homeDirectory: homeDirectory)
+        let sessionIds = Set(ledgerEntries.map { $0.sessionId })
+        let computed = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
         let dbDays = await Self.archive.freeze(
             homeDirectory: homeDirectory,
             computed: computed,

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeCostProvider.swift
@@ -19,9 +19,8 @@ public struct OpenCodeCostProvider: ProviderFetcher {
     let timeZone: TimeZone
     let environment: [String: String]
 
-    /// 永久每日归档（每个 home 一张，按 homeDirectory 区分以隔离测试 / 多配置）。
-    static let archive = OpenCodeUsageArchiveStore()
     /// 独立明细账本（message 级，按 message.id 去重增量），issue #67 的持久真相源。
+    /// 展示层直接用账本聚合，旧的 OpenCodeUsageArchiveStore 日归档已退役（避免「过去日冻结」阻止补采更新）。
     static let ledger = OpenCodeLedgerStore()
     static let defaultScanDays = 30
 
@@ -39,11 +38,16 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         let now = Date()
         let todayKey = dayKey(now)
 
-        // 首次（账本从未完成全量）触发全量扫描以回填账本全部明细；之后只扫窗口。
+        // 首次（账本从未完成全量）触发全量扫描以回填账本全部明细；之后从上次成功游标带安全重叠补采。
         let shouldImportFullHistory = await Self.ledger.consumeFullHistoryImportRequest(homeDirectory: homeDirectory)
-        let sinceMillis: Int64? = shouldImportFullHistory ? nil : scanWindowStartMillis(now: now)
+        let lastSuccessfulScanMillis = await Self.ledger.lastSuccessfulScanMillis(homeDirectory: homeDirectory)
+        let sinceMillis = Self.scanSinceMillis(
+            shouldImportFullHistory: shouldImportFullHistory,
+            lastSuccessfulScanMillis: lastSuccessfulScanMillis,
+            fallbackMillis: scanWindowStartMillis(now: now)
+        )
 
-        // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/版本过旧时跳过，账本仍有历史）。
+        // 1) 读库明细 → 账本合并（upsert 增量；OpenCode 未安装/快照失败时不推进账本游标，下次重试）。
         let dataDirectory = resolveDataDirectory()
         if let dataDirectory {
             let snapshotPath = try makeDatabaseSnapshot(dataDirectory: dataDirectory)
@@ -59,21 +63,15 @@ public struct OpenCodeCostProvider: ProviderFetcher {
             await Self.ledger.merge(
                 homeDirectory: homeDirectory,
                 newEntries: entries,
-                completedFullHistory: shouldImportFullHistory
+                scanSucceeded: true
             )
         }
         relieveMallocPressure()
 
-        // 2) 账本聚合 → 冻结归档：昨日前首写冻结、今天从账本累积覆盖（删除会话后账本不删，统计不丢）。
+        // 2) 账本聚合直接作为展示源（账本即真相源，含补采回填的历史；不再走 archive 冻结避免旧值覆盖新账）。
         let ledgerEntries = await Self.ledger.allEntries(homeDirectory: homeDirectory)
         let sessionIds = Set(ledgerEntries.map { $0.sessionId })
-        let computed = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
-        let dbDays = await Self.archive.freeze(
-            homeDirectory: homeDirectory,
-            computed: computed,
-            todayKey: todayKey,
-            completedFullHistory: shouldImportFullHistory
-        )
+        let dbDays = OpenCodeLedgerStore.aggregateDays(ledgerEntries)
         // 3) 合并全局统一代理用量（来自代理日志永久归档，模型键同口径 `aiusage-<slug>/<model>`，
         //    同节点同模型与 db 直连自动并入同一行；db 侧已排除裸全局 provider，两源互斥不双计）。
         //    即使本地 db 为空，只要有代理用量也照常呈现。
@@ -166,6 +164,23 @@ public struct OpenCodeCostProvider: ProviderFetcher {
         usage.source = source
         return usage
     }
+
+    /// 扫描窗口起点（epoch 毫秒）：全量 → nil；已有游标 → 游标带 24h 安全重叠补采；无游标 → 回退默认窗口。
+    static func scanSinceMillis(
+        shouldImportFullHistory: Bool,
+        lastSuccessfulScanMillis: Int64?,
+        fallbackMillis: Int64
+    ) -> Int64? {
+        if shouldImportFullHistory {
+            return nil
+        }
+        if let lastScan = lastSuccessfulScanMillis {
+            return lastScan - scanOverlapMillis
+        }
+        return fallbackMillis
+    }
+
+    static let scanOverlapMillis: Int64 = 24 * 3600 * 1000
 
     func relieveMallocPressure() {
         #if canImport(Darwin)

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -58,14 +58,15 @@ struct OpenCodeLedger: Codable, Sendable {
     var fullHistoryImportedAt: String?
     /// 最后一次成功扫描时间（epoch 毫秒），作为增量补采游标。nil = 尚未成功扫描过。
     var lastSuccessfulScanMillis: Int64?
-    /// 旧 usage-archive 一次性迁入的历史日（冻结快照，账本聚合覆盖重叠日，删会话独有日据此保留）。nil = 尚未迁移。
-    var legacyDays: [String: CodexAggregateBucket]?
+    /// 旧 usage-archive 迁移后的「残差」（max(旧归档 - 迁移时账本快照, 0)，按 day+model 冻结）。
+    /// 迁移后展示恒为「当前账本 + 残差」，完全重叠不重复、完全删除不丢、同日部分删除也不丢。nil = 尚未迁移。
+    var legacyResidualDays: [String: CodexAggregateBucket]?
     /// 旧 usage-archive 迁移完成时间（ISO8601）。nil = 尚未迁移。
     var legacyArchiveMigratedAt: String?
 }
 
 actor OpenCodeLedgerStore {
-    static let artifactVersion = 1
+    static let artifactVersion = 2
 
     private var ledgers: [String: OpenCodeLedger] = [:]
     private var loaded: Set<String> = []
@@ -132,32 +133,88 @@ actor OpenCodeLedgerStore {
         load(homeDirectory).legacyArchiveMigratedAt == nil
     }
 
-    /// 一次性把旧 usage-archive 的「过去日」迁入账本（幂等，迁移完成状态持久化）：
-    /// 迁入后设置 legacyArchiveMigratedAt 标记，旧归档不再参与展示，改由账本负责迁移后的增量。
-    /// 今天由账本实时维护，不迁入（旧归档的今天快照会过期）。
+    /// 账本是否已完成全量历史导入（全量导入成功是旧归档迁移的前置条件——只有账本回填了全部
+    /// 明细后，用「迁移时账本快照」算出的残差才完整，否则会把未回填的删会话记录错当成残差）。
+    func isFullHistoryImported(homeDirectory: String) -> Bool {
+        load(homeDirectory).fullHistoryImportedAt != nil
+    }
+
+    /// 一次性把旧 usage-archive 迁入账本为「残差」（幂等，迁移完成状态持久化）：
+    /// `residual = max(legacy - ledgerSnapshot, 0)`，按 day+model 逐字段相减钳制。
+    /// 迁移后展示恒为「当前账本 + 残差」：完全重叠不重复、完全删除不丢、同日部分删除也不丢；
+    /// 迁移后新记录继续由账本正常增量。今天由账本实时维护，不参与残差（旧归档今天快照会过期）。
     func migrateLegacyArchiveIfNeeded(
         homeDirectory: String,
         legacyDays: [String: CodexAggregateBucket],
+        ledgerSnapshotDays: [String: CodexAggregateBucket],
         todayKey: String
     ) {
         var ledger = load(homeDirectory)
         guard ledger.legacyArchiveMigratedAt == nil else { return }
 
-        var migrated: [String: CodexAggregateBucket] = [:]
-        for (day, bucket) in legacyDays where day != todayKey {
-            migrated[day] = bucket
-        }
+        let residual = Self.residualDays(
+            legacyDays: legacyDays,
+            ledgerSnapshotDays: ledgerSnapshotDays,
+            todayKey: todayKey
+        )
 
-        ledger.legacyDays = migrated
+        ledger.legacyResidualDays = residual
         ledger.legacyArchiveMigratedAt = SharedFormatters.iso8601String(from: Date())
         ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
         ledgers[homeDirectory] = ledger
         save(homeDirectory, ledger)
     }
 
-    /// 已迁入的历史日（冻结快照）。展示时账本聚合覆盖重叠日，删会话独有日据此保留。
-    func legacyDays(homeDirectory: String) -> [String: CodexAggregateBucket] {
-        load(homeDirectory).legacyDays ?? [:]
+    /// 已迁入的残差（冻结快照）。展示时叠加到账本聚合之上，删会话独有部分据此保留、重叠部分不双计。
+    func legacyResidualDays(homeDirectory: String) -> [String: CodexAggregateBucket] {
+        load(homeDirectory).legacyResidualDays ?? [:]
+    }
+
+    /// 计算旧归档相对「迁移时账本快照」的残差：`max(legacy - ledgerSnapshot, 0)`。
+    /// 按 day+model 逐字段相减钳制（input/output/cacheRead/cacheCreate/totalTokens/cost 各自独立），
+    /// 日汇总（totalTokens/cost）从模型残差重新聚合，usageRows 桶级相减钳制。今天不参与。
+    static func residualDays(
+        legacyDays: [String: CodexAggregateBucket],
+        ledgerSnapshotDays: [String: CodexAggregateBucket],
+        todayKey: String
+    ) -> [String: CodexAggregateBucket] {
+        var residual: [String: CodexAggregateBucket] = [:]
+        for (day, legacyBucket) in legacyDays where day != todayKey {
+            let ledgerBucket = ledgerSnapshotDays[day] ?? .empty
+            var residualBucket = CodexAggregateBucket.empty
+
+            for (modelName, legacyModel) in legacyBucket.models {
+                let ledgerModel = ledgerBucket.models[modelName] ?? CodexModelAggregate(model: modelName)
+                let input = max(legacyModel.inputTokens - ledgerModel.inputTokens, 0)
+                let output = max(legacyModel.outputTokens - ledgerModel.outputTokens, 0)
+                let cacheRead = max(legacyModel.cacheReadTokens - ledgerModel.cacheReadTokens, 0)
+                let cacheCreate = max(legacyModel.cacheCreateTokens - ledgerModel.cacheCreateTokens, 0)
+                let total = max(legacyModel.totalTokens - ledgerModel.totalTokens, 0)
+                let cost = max(legacyModel.estimatedCostUsd - ledgerModel.estimatedCostUsd, 0)
+                if total == 0, cost == 0, input == 0, output == 0, cacheRead == 0, cacheCreate == 0 {
+                    continue
+                }
+                residualBucket.models[modelName] = CodexModelAggregate(
+                    model: modelName,
+                    totalTokens: total,
+                    inputTokens: input,
+                    outputTokens: output,
+                    cacheReadTokens: cacheRead,
+                    cacheCreateTokens: cacheCreate,
+                    unpricedRequests: 0,
+                    estimatedCostUsd: cost
+                )
+                residualBucket.totalTokens += total
+                residualBucket.estimatedCostUsd += cost
+            }
+
+            residualBucket.usageRows = max(legacyBucket.usageRows - ledgerBucket.usageRows, 0)
+
+            if !residualBucket.models.isEmpty || residualBucket.usageRows > 0 {
+                residual[day] = residualBucket
+            }
+        }
+        return residual
     }
 
     /// 从明细聚合日桶（复用 CodexAggregateBucket.record）。

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+import os.log
+
+private let openCodeLedgerLog = Logger(subsystem: "com.aiusage.quotabackend", category: "OpenCodeLedger")
+
+// MARK: - OpenCode Ledger Store
+// OpenCode 本地会话用量的「独立明细账本」（issue #67）。
+// 与 usage-archive 的「日聚合冻结」不同，本账本按 message 级明细持久化，
+// 以 opencode.db message.id 为主键做 upsert，从而在 opencode 侧删除会话 / 清空历史后，
+// 已记录的 token/cost 明细仍可追溯、不丢失。
+//
+// 语义：
+// - upsert：本次扫描读到的 message（按 id）覆盖旧值——处理 opencode 流式过程中 token 数的渐进更新。
+// - 保留：本次扫描读不到的 message（opencode 侧已删除，或超出扫描窗口）不从账本删除——删除不丢账。
+//
+// 持久化（永久、放 ~/.config/aiusage 避免被系统清理）:
+//   <home>/.config/aiusage/usage-archive/opencode-ledger-v<version>.json
+// 与 usage-archive 同目录但独立文件，避免污染 Codex/Claude 共享的 CodexUsageArchive 结构。
+
+/// 一条 assistant 消息的完整用量明细（满足 issue #67「明细可追溯」：时间/模型/各类型 token/cost）。
+struct OpenCodeLedgerEntry: Codable, Sendable, Equatable {
+    /// opencode.db message.id（text 主键，如 `msg_xxx`），账本去重键。
+    let messageId: String
+    let sessionId: String
+    /// 消息创建时间（epoch 毫秒，来自 message.time_created）。
+    let timeCreatedMillis: Int64
+    /// 归属日（yyyy-MM-dd，解析时按 provider 时区固定，避免时区漂移）。
+    let dayKey: String
+    /// 模型名口径 `providerID/modelID`。
+    let model: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheCreateTokens: Int
+    let totalTokens: Int
+    /// models.dev 定价的冻结成本（订阅渠道恒 0，非「未定价」）。
+    let estimatedCostUsd: Double
+
+    func asCodexRow() -> CodexRow {
+        CodexRow(
+            dayKey: dayKey,
+            model: model,
+            inputTokens: inputTokens,
+            cacheReadTokens: cacheReadTokens,
+            cacheCreateTokens: cacheCreateTokens,
+            outputTokens: outputTokens,
+            totalTokens: totalTokens,
+            estimatedCostUsd: estimatedCostUsd
+        )
+    }
+}
+
+/// 账本文件结构（version 1）。
+struct OpenCodeLedger: Codable, Sendable {
+    let version: Int
+    var updatedAt: String
+    var entries: [String: OpenCodeLedgerEntry]
+    var fullHistoryImportedAt: String?
+}
+
+actor OpenCodeLedgerStore {
+    static let artifactVersion = 1
+
+    private var ledgers: [String: OpenCodeLedger] = [:]
+    private var loaded: Set<String> = []
+
+    /// 首次返回 true（触发一次全量扫描以回填账本全部明细），完成后恒 false。
+    func consumeFullHistoryImportRequest(homeDirectory: String) -> Bool {
+        load(homeDirectory).fullHistoryImportedAt == nil
+    }
+
+    /// 按 messageId upsert 合并本次读到的明细；账本中读不到的条目保留（删除不丢）。
+    /// 返回合并后的全部明细，供调用方聚合与 sessionCount 统计。
+    @discardableResult
+    func merge(
+        homeDirectory: String,
+        newEntries: [OpenCodeLedgerEntry],
+        completedFullHistory: Bool
+    ) -> [OpenCodeLedgerEntry] {
+        var ledger = load(homeDirectory)
+        var changed = false
+
+        for entry in newEntries {
+            if ledger.entries[entry.messageId] != entry {
+                ledger.entries[entry.messageId] = entry
+                changed = true
+            }
+        }
+
+        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
+            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+            changed = true
+        }
+
+        if changed {
+            ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+            ledgers[homeDirectory] = ledger
+            save(homeDirectory, ledger)
+        } else {
+            ledgers[homeDirectory] = ledger
+        }
+        return Array(ledger.entries.values)
+    }
+
+    /// 读取账本全部明细（不触发写）。
+    func allEntries(homeDirectory: String) -> [OpenCodeLedgerEntry] {
+        Array(load(homeDirectory).entries.values)
+    }
+
+    /// 从明细聚合日桶（复用 CodexAggregateBucket.record）。
+    static func aggregateDays(_ entries: [OpenCodeLedgerEntry]) -> [String: CodexAggregateBucket] {
+        var days: [String: CodexAggregateBucket] = [:]
+        for entry in entries {
+            days[entry.dayKey, default: .empty].record(row: entry.asCodexRow())
+        }
+        return days
+    }
+
+    // MARK: Disk
+
+    private func load(_ homeDirectory: String) -> OpenCodeLedger {
+        if let ledger = ledgers[homeDirectory], loaded.contains(homeDirectory) { return ledger }
+        loaded.insert(homeDirectory)
+
+        if let data = try? Data(contentsOf: Self.fileURL(homeDirectory: homeDirectory)),
+           let decoded = try? JSONDecoder().decode(OpenCodeLedger.self, from: data),
+           decoded.version == Self.artifactVersion {
+            ledgers[homeDirectory] = decoded
+            return decoded
+        }
+
+        let fresh = OpenCodeLedger(version: Self.artifactVersion, updatedAt: "", entries: [:])
+        ledgers[homeDirectory] = fresh
+        return fresh
+    }
+
+    private func save(_ homeDirectory: String, _ ledger: OpenCodeLedger) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(ledger)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            openCodeLedgerLog.warning("Failed to save OpenCode ledger: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    static func fileURL(homeDirectory: String) -> URL {
+        let dir = (homeDirectory as NSString).appendingPathComponent(".config/aiusage/usage-archive")
+        return URL(fileURLWithPath: dir, isDirectory: true)
+            .appendingPathComponent("opencode-ledger-v\(artifactVersion).json")
+    }
+}

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -56,6 +56,8 @@ struct OpenCodeLedger: Codable, Sendable {
     var updatedAt: String
     var entries: [String: OpenCodeLedgerEntry]
     var fullHistoryImportedAt: String?
+    /// 最后一次成功扫描时间（epoch 毫秒），作为增量补采游标。nil = 尚未成功扫描过。
+    var lastSuccessfulScanMillis: Int64?
 }
 
 actor OpenCodeLedgerStore {
@@ -69,13 +71,20 @@ actor OpenCodeLedgerStore {
         load(homeDirectory).fullHistoryImportedAt == nil
     }
 
+    /// 最后一次成功扫描时间（epoch 毫秒）。nil = 尚未成功扫描过（或旧账本无此字段）。
+    func lastSuccessfulScanMillis(homeDirectory: String) -> Int64? {
+        load(homeDirectory).lastSuccessfulScanMillis
+    }
+
     /// 按 messageId upsert 合并本次读到的明细；账本中读不到的条目保留（删除不丢）。
+    /// `scanSucceeded` 为 true 时才推进「全量导入完成」标记与补采游标；
+    /// 失败（DB 快照/查询失败、目录不可用）保留原状态，下次重试。
     /// 返回合并后的全部明细，供调用方聚合与 sessionCount 统计。
     @discardableResult
     func merge(
         homeDirectory: String,
         newEntries: [OpenCodeLedgerEntry],
-        completedFullHistory: Bool
+        scanSucceeded: Bool
     ) -> [OpenCodeLedgerEntry] {
         var ledger = load(homeDirectory)
         var changed = false
@@ -87,9 +96,16 @@ actor OpenCodeLedgerStore {
             }
         }
 
-        if completedFullHistory, ledger.fullHistoryImportedAt == nil {
-            ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
-            changed = true
+        if scanSucceeded {
+            if ledger.fullHistoryImportedAt == nil {
+                ledger.fullHistoryImportedAt = SharedFormatters.iso8601String(from: Date())
+                changed = true
+            }
+            let nowMillis = Int64(Date().timeIntervalSince1970 * 1000)
+            if ledger.lastSuccessfulScanMillis != nowMillis {
+                ledger.lastSuccessfulScanMillis = nowMillis
+                changed = true
+            }
         }
 
         if changed {

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeLedgerStore.swift
@@ -58,6 +58,10 @@ struct OpenCodeLedger: Codable, Sendable {
     var fullHistoryImportedAt: String?
     /// 最后一次成功扫描时间（epoch 毫秒），作为增量补采游标。nil = 尚未成功扫描过。
     var lastSuccessfulScanMillis: Int64?
+    /// 旧 usage-archive 一次性迁入的历史日（冻结快照，账本聚合覆盖重叠日，删会话独有日据此保留）。nil = 尚未迁移。
+    var legacyDays: [String: CodexAggregateBucket]?
+    /// 旧 usage-archive 迁移完成时间（ISO8601）。nil = 尚未迁移。
+    var legacyArchiveMigratedAt: String?
 }
 
 actor OpenCodeLedgerStore {
@@ -121,6 +125,39 @@ actor OpenCodeLedgerStore {
     /// 读取账本全部明细（不触发写）。
     func allEntries(homeDirectory: String) -> [OpenCodeLedgerEntry] {
         Array(load(homeDirectory).entries.values)
+    }
+
+    /// 旧 usage-archive 是否尚未迁移（幂等判断）。
+    func needsLegacyArchiveMigration(homeDirectory: String) -> Bool {
+        load(homeDirectory).legacyArchiveMigratedAt == nil
+    }
+
+    /// 一次性把旧 usage-archive 的「过去日」迁入账本（幂等，迁移完成状态持久化）：
+    /// 迁入后设置 legacyArchiveMigratedAt 标记，旧归档不再参与展示，改由账本负责迁移后的增量。
+    /// 今天由账本实时维护，不迁入（旧归档的今天快照会过期）。
+    func migrateLegacyArchiveIfNeeded(
+        homeDirectory: String,
+        legacyDays: [String: CodexAggregateBucket],
+        todayKey: String
+    ) {
+        var ledger = load(homeDirectory)
+        guard ledger.legacyArchiveMigratedAt == nil else { return }
+
+        var migrated: [String: CodexAggregateBucket] = [:]
+        for (day, bucket) in legacyDays where day != todayKey {
+            migrated[day] = bucket
+        }
+
+        ledger.legacyDays = migrated
+        ledger.legacyArchiveMigratedAt = SharedFormatters.iso8601String(from: Date())
+        ledger.updatedAt = SharedFormatters.iso8601String(from: Date())
+        ledgers[homeDirectory] = ledger
+        save(homeDirectory, ledger)
+    }
+
+    /// 已迁入的历史日（冻结快照）。展示时账本聚合覆盖重叠日，删会话独有日据此保留。
+    func legacyDays(homeDirectory: String) -> [String: CodexAggregateBucket] {
+        load(homeDirectory).legacyDays ?? [:]
     }
 
     /// 从明细聚合日桶（复用 CodexAggregateBucket.record）。

--- a/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeUsageArchiveStore.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Providers/OpenCodeUsageArchiveStore.swift
@@ -67,6 +67,11 @@ actor OpenCodeUsageArchiveStore {
 
     // MARK: Disk
 
+    /// 只读旧归档全部日（一次性迁移用，不触发写）。
+    func days(homeDirectory: String) -> [String: CodexAggregateBucket] {
+        load(homeDirectory).days
+    }
+
     private func load(_ homeDirectory: String) -> CodexUsageArchive {
         if let archive = archives[homeDirectory], loaded.contains(homeDirectory) { return archive }
         loaded.insert(homeDirectory)

--- a/QuotaBackend/Sources/QuotaBackend/Utilities/ExtraParametersApplier.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Utilities/ExtraParametersApplier.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// 每模型追加参数（issue #69）的纯解析/合并工具：把字符串值解析为 JSON 标量/对象/数组，
+/// 再按点路径合并进模型 entry。从 AIUsage 侧抽到 QuotaBackend，便于 QuotaBackendTests 覆盖。
+public enum ExtraParametersApplier {
+
+    /// 把每模型追加参数按点路径合并进模型 entry，覆盖节点级默认（issue #69）。
+    /// 值存字符串，此处智能解析为 JSON 标量/对象/数组后写入。
+    public static func applyExtraParameters(
+        _ parameters: [String: String],
+        to entry: [String: Any]
+    ) -> [String: Any] {
+        var result = entry
+        // 按 key 字典序排序：父子路径冲突（如 "limit" 与 "limit.context"）时父路径先写、
+        // 子路径后写覆盖，结果确定，不依赖字典遍历顺序。
+        for (key, rawValue) in parameters.sorted(by: { $0.key < $1.key }) {
+            guard let value = parseParameterValue(rawValue) else { continue }
+            setNestedValue(value, atPath: key, in: &result)
+        }
+        return result
+    }
+
+    /// 把字符串值解析为 JSON 值：整数/浮点/布尔/null 字面量、`{...}`/`[...]` 走 JSON 解析，
+    /// 其余原样保留为字符串。
+    public static func parseParameterValue(_ rawValue: String) -> Any? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        if let intValue = Int(trimmed) { return intValue }
+        if let doubleValue = Double(trimmed), trimmed.contains(".") { return doubleValue }
+        switch trimmed.lowercased() {
+        case "true": return true
+        case "false": return false
+        case "null", "nil": return NSNull()
+        default: break
+        }
+        if trimmed.hasPrefix("{") || trimmed.hasPrefix("[") {
+            if let data = trimmed.data(using: .utf8),
+               let object = try? JSONSerialization.jsonObject(with: data) {
+                return object
+            }
+        }
+        return rawValue
+    }
+
+    /// 按点路径（如 "limit.context"）把值写入嵌套字典；多段 key 逐层创建中间字典。
+    public static func setNestedValue(
+        _ value: Any,
+        atPath path: String,
+        in dict: inout [String: Any]
+    ) {
+        let components = path.split(separator: ".").map(String.init).filter { !$0.isEmpty }
+        guard let first = components.first else { return }
+        if components.count == 1 {
+            dict[first] = value
+            return
+        }
+        var child = dict[first] as? [String: Any] ?? [:]
+        setNestedValue(value, atPath: components.dropFirst().joined(separator: "."), in: &child)
+        dict[first] = child
+    }
+}

--- a/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
@@ -160,22 +160,40 @@ public enum JSONCEditor {
         // 若吞逗号，delStart 会落在 lastKept 值结束处，与 appendInsertEdits 以 lastKept.node.end 为起点的插入区间重叠，导致 applyEdits 返回 nil、merge 失败并退化到丢注释的 writeObject。
         let hasInserts = target.keys.contains { existing[$0] == nil }
         if !allMembersDeleted {
-            for (idx, member) in node.members.enumerated() where target[member.key] == nil {
-                if idx + 1 < node.members.count {
-                    // 中间成员：删除到下一个成员起始位置（含当前成员的尾逗号）。
-                    let delEnd = node.members[idx + 1].memberStart
-                    edits.append(Edit(start: member.memberStart, end: delEnd, replacement: ""))
-                } else if hasInserts {
-                    // 最后一个成员且后续有新增键：不吞前导逗号，把逗号/空白留给插入锚点一并替换，避免区间重叠。
-                    edits.append(Edit(start: member.memberStart, end: member.node.end, replacement: ""))
-                } else {
-                    // 最后一个成员且无新增键：前向跳过空白找到前导逗号，删除到值结束位置（保留对象闭合前导换行）。
-                    var delStart = member.memberStart
-                    var i = member.memberStart - 1
-                    while i >= 0 && isWhitespace(node.chars[i]) { i -= 1 }
-                    if i >= 0 && node.chars[i] == "," { delStart = i }
-                    edits.append(Edit(start: delStart, end: member.node.end, replacement: ""))
+            // 按「连续被删成员段」整体删除：每段一个 edit，段内成员之间不产生多个 edit。
+            // 逐个删除时「中间成员删除 [a.memberStart, b.memberStart]」与「最后成员删除 [a.node.end, b.node.end]」
+            // 会在 [a.node.end, b.memberStart) 区间重叠（a.node.end < b.memberStart，中间是逗号+换行），
+            // 导致 applyEdits 返回 nil、merge 退化到丢注释的 writeObject。合并段后每段边界衔接、不重叠。
+            var idx = 0
+            while idx < node.members.count {
+                guard target[node.members[idx].key] == nil else { idx += 1; continue }
+                var segEnd = idx
+                while segEnd < node.members.count && target[node.members[segEnd].key] == nil {
+                    segEnd += 1
                 }
+                let segStart = node.members[idx]
+                let segLast = node.members[segEnd - 1]
+                var delStart = segStart.memberStart
+                var delEnd: Int
+                if segEnd < node.members.count {
+                    // 段后还有保留成员：删除整段 + 段尾尾逗号（保留段前保留成员的尾逗号作分隔）。
+                    delEnd = node.members[segEnd].memberStart
+                } else {
+                    // 段尾是最后一个成员：删除到段尾值结束，并吞掉紧跟的尾逗号（若有），避免逗号残留。
+                    delEnd = segLast.node.end
+                    if delEnd < node.chars.count, node.chars[delEnd] == "," {
+                        delEnd += 1
+                    }
+                    if idx > 0 && !hasInserts {
+                        // 无新增键：前向跳过空白吞掉前导逗号，避免逗号残留。
+                        // 有新增键则保留前导逗号，交由 appendInsertEdits 的插入锚点一并替换。
+                        var k = segStart.memberStart - 1
+                        while k >= 0 && isWhitespace(node.chars[k]) { k -= 1 }
+                        if k >= 0 && node.chars[k] == "," { delStart = k }
+                    }
+                }
+                edits.append(Edit(start: delStart, end: delEnd, replacement: ""))
+                idx = segEnd
             }
         }
 

--- a/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
@@ -156,14 +156,20 @@ public enum JSONCEditor {
         // 删除：原文中存在但目标已无的键（连同其分隔逗号/前导空白到下一个键）。
         // 若所有成员都将被删除，则跳过逐个删除，交由 appendInsertEdits 整体重排，避免残留前导空白。
         let allMembersDeleted = !node.members.isEmpty && node.members.allSatisfy { target[$0.key] == nil }
+        // 是否存在新增键：删除最后一个成员时据此决定是否前移吞逗号。
+        // 若吞逗号，delStart 会落在 lastKept 值结束处，与 appendInsertEdits 以 lastKept.node.end 为起点的插入区间重叠，导致 applyEdits 返回 nil、merge 失败并退化到丢注释的 writeObject。
+        let hasInserts = target.keys.contains { existing[$0] == nil }
         if !allMembersDeleted {
             for (idx, member) in node.members.enumerated() where target[member.key] == nil {
                 if idx + 1 < node.members.count {
                     // 中间成员：删除到下一个成员起始位置（含当前成员的尾逗号）。
                     let delEnd = node.members[idx + 1].memberStart
                     edits.append(Edit(start: member.memberStart, end: delEnd, replacement: ""))
+                } else if hasInserts {
+                    // 最后一个成员且后续有新增键：不吞前导逗号，把逗号/空白留给插入锚点一并替换，避免区间重叠。
+                    edits.append(Edit(start: member.memberStart, end: member.node.end, replacement: ""))
                 } else {
-                    // 最后一个成员：前向跳过空白找到前导逗号，删除到值结束位置（保留对象闭合前导换行）。
+                    // 最后一个成员且无新增键：前向跳过空白找到前导逗号，删除到值结束位置（保留对象闭合前导换行）。
                     var delStart = member.memberStart
                     var i = member.memberStart - 1
                     while i >= 0 && isWhitespace(node.chars[i]) { i -= 1 }
@@ -214,6 +220,12 @@ public enum JSONCEditor {
             // 若 lastKept 后紧跟尾随逗号（原文不规范），把它一并替换，避免逗号残留到新增键之后。
             if insertEnd < node.chars.count, node.chars[insertEnd] == "," {
                 insertEnd += 1
+            }
+            // 若 lastKept 之后还有被删除的成员，插入区间需扩展到首个被删成员起始，把中间的逗号/空白一并替换，
+            // 与「删除最后成员（不吞逗号）」的区间衔接（[lastKept.node.end, memberStart) + [memberStart, ...)），避免重叠和空行残留。
+            if let keptIdx = node.members.firstIndex(where: { $0.key == lastKept.key }),
+               keptIdx + 1 < node.members.count {
+                insertEnd = node.members[keptIdx + 1].memberStart
             }
             var text = ""
             for (key, value) in sortedInserts {

--- a/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
+++ b/QuotaBackend/Sources/QuotaBackend/Utilities/JSONCEditor.swift
@@ -39,6 +39,84 @@ public enum JSONCEditor {
         return patched
     }
 
+    /// 重新格式化 JSONC 文本：修复缩进与尾随逗号，保留注释。
+    /// - Returns: 格式化后的文本；解析失败（非对象根）时返回 nil。
+    public static func format(_ text: String) -> String? {
+        let chars = Array(text)
+        var parser = Parser(chars: chars)
+        guard let root = try? parser.parseDocument(), root.kind == .object else { return nil }
+        let indentUnit = detectIndentUnit(chars)
+        var out = ""
+        render(node: root, level: 0, indentUnit: indentUnit, chars: chars, out: &out)
+        return out
+    }
+
+    private static func render(node: Node, level: Int, indentUnit: String, chars: [Character], out: inout String) {
+        let indent = String(repeating: indentUnit, count: level)
+        let childIndent = String(repeating: indentUnit, count: level + 1)
+
+        switch node.kind {
+        case .object:
+            out += "{\n"
+            var prevEnd = node.contentStart
+            for (idx, member) in node.members.enumerated() {
+                renderComments(from: prevEnd, to: member.memberStart, indent: childIndent, chars: chars, out: &out)
+                out += childIndent + "\"\(escapeString(member.key))\": "
+                render(node: member.node, level: level + 1, indentUnit: indentUnit, chars: chars, out: &out)
+                if idx < node.members.count - 1 { out += "," }
+                out += "\n"
+                prevEnd = member.node.end
+            }
+            renderComments(from: prevEnd, to: node.contentEnd, indent: childIndent, chars: chars, out: &out)
+            out += indent + "}"
+        case .array:
+            out += "[\n"
+            var prevEnd = node.contentStart
+            for (idx, element) in node.elements.enumerated() {
+                renderComments(from: prevEnd, to: element.start, indent: childIndent, chars: chars, out: &out)
+                out += childIndent
+                render(node: element, level: level + 1, indentUnit: indentUnit, chars: chars, out: &out)
+                if idx < node.elements.count - 1 { out += "," }
+                out += "\n"
+                prevEnd = element.end
+            }
+            renderComments(from: prevEnd, to: node.contentEnd, indent: childIndent, chars: chars, out: &out)
+            out += indent + "]"
+        default:
+            out += String(chars[node.start..<node.end])
+        }
+    }
+
+    private static func renderComments(from: Int, to: Int, indent: String, chars: [Character], out: inout String) {
+        var i = from
+        while i < to {
+            let c = chars[i]
+            if c == " " || c == "\t" || c == "\r" || c == "\n" { i += 1; continue }
+            if c == "/", i + 1 < to, chars[i + 1] == "/" {
+                let start = i
+                while i < to && chars[i] != "\n" { i += 1 }
+                let comment = String(chars[start..<i]).trimmingCharacters(in: .whitespaces)
+                if !comment.isEmpty { out += indent + comment + "\n" }
+                continue
+            }
+            if c == "/", i + 1 < to, chars[i + 1] == "*" {
+                let start = i
+                i += 2
+                while i + 1 < to && !(chars[i] == "*" && chars[i + 1] == "/") { i += 1 }
+                i = min(i + 2, to)
+                let lines = String(chars[start..<i]).components(separatedBy: "\n")
+                for (li, line) in lines.enumerated() {
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    if trimmed.isEmpty { continue }
+                    out += indent + trimmed + (li < lines.count - 1 ? "\n" : "")
+                }
+                out += "\n"
+                continue
+            }
+            i += 1
+        }
+    }
+
     // MARK: - Edit Model
 
     private struct Edit {
@@ -76,9 +154,23 @@ public enum JSONCEditor {
         for member in node.members { existing[member.key] = member }
 
         // 删除：原文中存在但目标已无的键（连同其分隔逗号/前导空白到下一个键）。
-        for (idx, member) in node.members.enumerated() where target[member.key] == nil {
-            let delEnd = idx + 1 < node.members.count ? node.members[idx + 1].memberStart : node.contentEnd
-            edits.append(Edit(start: member.memberStart, end: delEnd, replacement: ""))
+        // 若所有成员都将被删除，则跳过逐个删除，交由 appendInsertEdits 整体重排，避免残留前导空白。
+        let allMembersDeleted = !node.members.isEmpty && node.members.allSatisfy { target[$0.key] == nil }
+        if !allMembersDeleted {
+            for (idx, member) in node.members.enumerated() where target[member.key] == nil {
+                if idx + 1 < node.members.count {
+                    // 中间成员：删除到下一个成员起始位置（含当前成员的尾逗号）。
+                    let delEnd = node.members[idx + 1].memberStart
+                    edits.append(Edit(start: member.memberStart, end: delEnd, replacement: ""))
+                } else {
+                    // 最后一个成员：前向跳过空白找到前导逗号，删除到值结束位置（保留对象闭合前导换行）。
+                    var delStart = member.memberStart
+                    var i = member.memberStart - 1
+                    while i >= 0 && isWhitespace(node.chars[i]) { i -= 1 }
+                    if i >= 0 && node.chars[i] == "," { delStart = i }
+                    edits.append(Edit(start: delStart, end: member.node.end, replacement: ""))
+                }
+            }
         }
 
         // 更新/递归 + 收集新增键。
@@ -118,22 +210,28 @@ public enum JSONCEditor {
 
         // 锚点优先选「最后一个保留下来的成员」之后插入：前导逗号 + 换行，逗号/无逗号原文都干净。
         if let lastKept = node.members.last(where: { target[$0.key] != nil }) {
+            var insertEnd = lastKept.node.end
+            // 若 lastKept 后紧跟尾随逗号（原文不规范），把它一并替换，避免逗号残留到新增键之后。
+            if insertEnd < node.chars.count, node.chars[insertEnd] == "," {
+                insertEnd += 1
+            }
             var text = ""
             for (key, value) in sortedInserts {
                 text += ",\n" + memberIndent + memberText(key, value)
             }
-            edits.append(Edit(start: lastKept.node.end, end: lastKept.node.end, replacement: text))
+            edits.append(Edit(start: lastKept.node.end, end: insertEnd, replacement: text))
             return
         }
 
-        // 对象为空（或成员将被全部删除）：花括号间若仅空白则整体重排为带新成员；否则在 `{` 后插入。
+        // 对象为空（或成员将被全部删除）：整体重排为带新成员；仅当对象本就为空且花括号间有注释时，在 `{` 后插入保留注释。
+        let allMembersDeleted = !node.members.isEmpty && node.members.allSatisfy { target[$0.key] == nil }
         let interIsBlank = (node.contentStart..<node.contentEnd).allSatisfy { isWhitespace(node.chars[$0]) }
         let body = sortedInserts.map { memberIndent + memberText($0.0, $0.1) }.joined(separator: ",\n")
-        if interIsBlank {
+        if allMembersDeleted || interIsBlank {
             let replacement = "\n" + body + "\n" + braceIndent
             edits.append(Edit(start: node.contentStart, end: node.contentEnd, replacement: replacement))
         } else {
-            let replacement = "\n" + body + ","
+            let replacement = "\n" + body
             edits.append(Edit(start: node.contentStart, end: node.contentStart, replacement: replacement))
         }
     }
@@ -254,11 +352,12 @@ public enum JSONCEditor {
         let start: Int
         var end: Int
         var value: Any
-        // object only
+        // container (object/array) only
         let chars: [Character]
         var members: [Member] = []
-        var contentStart: Int = 0   // `{` 之后的位置
-        var contentEnd: Int = 0     // `}` 所在位置
+        var elements: [Node] = []
+        var contentStart: Int = 0   // `{`/`[` 之后的位置
+        var contentEnd: Int = 0     // `}`/`]` 所在位置
 
         init(kind: Kind, start: Int, chars: [Character]) {
             self.kind = kind
@@ -362,15 +461,17 @@ public enum JSONCEditor {
             let node = Node(kind: .array, start: i, chars: chars)
             var array: [Any] = []
             i += 1
+            node.contentStart = i
             while true {
                 skipTrivia()
                 guard i < chars.count else { throw ParseError() }
-                if chars[i] == "]" { i += 1; break }
+                if chars[i] == "]" { node.contentEnd = i; i += 1; break }
                 let element = try parseValue()
                 array.append(element.value)
+                node.elements.append(element)
                 skipTrivia()
                 if i < chars.count, chars[i] == "," { i += 1; continue }
-                if i < chars.count, chars[i] == "]" { i += 1; break }
+                if i < chars.count, chars[i] == "]" { node.contentEnd = i; i += 1; break }
                 throw ParseError()
             }
             node.end = i

--- a/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
@@ -35,4 +35,57 @@ final class CallAnalyticsEngineTests: XCTestCase {
 
         XCTAssertEqual(cutoff, fallback)
     }
+
+    func testLegacyCallArchiveDoesNotDoubleCountAfterLedgerMigration() {
+        let opencodeBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1
+        )
+        let claudeBash = CallAnalyticsEntry(
+            source: .claude, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1
+        )
+
+        let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
+            entries: [opencodeBash, claudeBash],
+            day: "2026-01-01",
+            ledgerFullyImported: true,
+            ledgerOpenCodeDayKeys: ["2026-01-01"]
+        )
+
+        XCTAssertEqual(deduped.count, 1)
+        XCTAssertEqual(deduped.first?.source, .claude)
+    }
+
+    func testLegacyOpenCodeEntryPreservedWhenLedgerHasNoThatDay() {
+        let opencodeBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1
+        )
+
+        let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
+            entries: [opencodeBash],
+            day: "2026-01-01",
+            ledgerFullyImported: true,
+            ledgerOpenCodeDayKeys: []
+        )
+
+        XCTAssertEqual(deduped.count, 1)
+    }
+
+    func testLegacyOpenCodeEntryKeptWhenLedgerNotFullyImported() {
+        let opencodeBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1
+        )
+
+        let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
+            entries: [opencodeBash],
+            day: "2026-01-01",
+            ledgerFullyImported: false,
+            ledgerOpenCodeDayKeys: ["2026-01-01"]
+        )
+
+        XCTAssertEqual(deduped.count, 1)
+    }
 }

--- a/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import QuotaBackend
+
+final class CallAnalyticsEngineTests: XCTestCase {
+    func testOpenCodeScanCutoffFullImportReturnsNil() {
+        let cutoff = CallAnalyticsEngine.openCodeScanCutoff(
+            ledgerNeedsFullImport: true,
+            lastSuccessfulScanDate: Date(timeIntervalSince1970: 1_700_000_000),
+            fallbackCutoff: Date(timeIntervalSince1970: 1_700_100_000)
+        )
+        XCTAssertNil(cutoff)
+    }
+
+    func testOpenCodeScanCutoffUsesCursorMinusOverlap() {
+        let cursor = Date(timeIntervalSince1970: 1_700_000_000)
+        let fallback = Date(timeIntervalSince1970: 1_700_100_000)
+
+        let cutoff = CallAnalyticsEngine.openCodeScanCutoff(
+            ledgerNeedsFullImport: false,
+            lastSuccessfulScanDate: cursor,
+            fallbackCutoff: fallback
+        )
+
+        XCTAssertEqual(cutoff, cursor.addingTimeInterval(-24 * 3600))
+    }
+
+    func testOpenCodeScanCutoffFallsBackWhenNoCursor() {
+        let fallback = Date(timeIntervalSince1970: 1_700_100_000)
+
+        let cutoff = CallAnalyticsEngine.openCodeScanCutoff(
+            ledgerNeedsFullImport: false,
+            lastSuccessfulScanDate: nil,
+            fallbackCutoff: fallback
+        )
+
+        XCTAssertEqual(cutoff, fallback)
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/CallAnalyticsEngineTests.swift
@@ -36,7 +36,7 @@ final class CallAnalyticsEngineTests: XCTestCase {
         XCTAssertEqual(cutoff, fallback)
     }
 
-    func testLegacyCallArchiveDoesNotDoubleCountAfterLedgerMigration() {
+    func testLegacyOpenCodeDroppedWhenLegacyArchiveMigrated() {
         let opencodeBash = CallAnalyticsEntry(
             source: .opencode, kind: .builtin, name: "bash", server: nil,
             dayKey: "2026-01-01", count: 1
@@ -48,16 +48,14 @@ final class CallAnalyticsEngineTests: XCTestCase {
 
         let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
             entries: [opencodeBash, claudeBash],
-            day: "2026-01-01",
-            ledgerFullyImported: true,
-            ledgerOpenCodeDayKeys: ["2026-01-01"]
+            legacyArchiveMigrated: true
         )
 
         XCTAssertEqual(deduped.count, 1)
         XCTAssertEqual(deduped.first?.source, .claude)
     }
 
-    func testLegacyOpenCodeEntryPreservedWhenLedgerHasNoThatDay() {
+    func testLegacyOpenCodeEntryKeptWhenArchiveNotMigrated() {
         let opencodeBash = CallAnalyticsEntry(
             source: .opencode, kind: .builtin, name: "bash", server: nil,
             dayKey: "2026-01-01", count: 1
@@ -65,27 +63,67 @@ final class CallAnalyticsEngineTests: XCTestCase {
 
         let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
             entries: [opencodeBash],
-            day: "2026-01-01",
-            ledgerFullyImported: true,
-            ledgerOpenCodeDayKeys: []
+            legacyArchiveMigrated: false
         )
 
         XCTAssertEqual(deduped.count, 1)
+        XCTAssertEqual(deduped.first?.source, .opencode)
     }
 
-    func testLegacyOpenCodeEntryKeptWhenLedgerNotFullyImported() {
-        let opencodeBash = CallAnalyticsEntry(
+    func testResidualEntriesPreservesPartialSameDayDeletion() {
+        let legacyBash = CallAnalyticsEntry(
             source: .opencode, kind: .builtin, name: "bash", server: nil,
-            dayKey: "2026-01-01", count: 1
+            dayKey: "2026-01-01", count: 2, outcomeKnownCount: 2, successCount: 2
+        )
+        let legacyRead = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "read", server: nil,
+            dayKey: "2026-01-01", count: 1, outcomeKnownCount: 1, successCount: 1
+        )
+        let ledgerBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1, outcomeKnownCount: 1, successCount: 1
         )
 
-        let deduped = CallAnalyticsEngine.deduplicateLegacyOpenCode(
-            entries: [opencodeBash],
-            day: "2026-01-01",
-            ledgerFullyImported: false,
-            ledgerOpenCodeDayKeys: ["2026-01-01"]
+        let residual = CallAnalyticsEngine.residualEntries(
+            legacy: [legacyBash, legacyRead],
+            ledger: [ledgerBash]
         )
 
-        XCTAssertEqual(deduped.count, 1)
+        XCTAssertEqual(residual.count, 2)
+        XCTAssertEqual(residual.first(where: { $0.name == "bash" })?.count, 1)
+        XCTAssertEqual(residual.first(where: { $0.name == "read" })?.count, 1)
+    }
+
+    func testResidualEntriesEmptyWhenFullyOverlapped() {
+        let legacyBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1, outcomeKnownCount: 1, successCount: 1
+        )
+        let ledgerBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 1, outcomeKnownCount: 1, successCount: 1
+        )
+
+        let residual = CallAnalyticsEngine.residualEntries(
+            legacy: [legacyBash],
+            ledger: [ledgerBash]
+        )
+
+        XCTAssertTrue(residual.isEmpty)
+    }
+
+    func testResidualEntriesKeepsFullyDeletedEntry() {
+        let legacyBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-01", count: 2, outcomeKnownCount: 2, successCount: 2
+        )
+
+        let residual = CallAnalyticsEngine.residualEntries(
+            legacy: [legacyBash],
+            ledger: []
+        )
+
+        XCTAssertEqual(residual.count, 1)
+        XCTAssertEqual(residual.first?.count, 2)
     }
 }

--- a/QuotaBackend/Tests/QuotaBackendTests/ExtraParametersApplierTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/ExtraParametersApplierTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import QuotaBackend
+
+/// 覆盖 issue #69 每模型追加参数的解析与合并：标量/结构化解析、点路径、父子路径冲突确定性、
+/// 无效 JSON 风格输入的明确行为。
+final class ExtraParametersApplierTests: XCTestCase {
+
+    // MARK: - parseParameterValue 标量
+
+    func testParseParameterValueScalars() {
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("hello") as? String, "hello")
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("123") as? Int, 123)
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("-42") as? Int, -42)
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("1.5") as? Double, 1.5)
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("true") as? Bool, true)
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("false") as? Bool, false)
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("TRUE") as? Bool, true)
+    }
+
+    func testParseParameterValueNullAndEmpty() {
+        XCTAssertTrue(ExtraParametersApplier.parseParameterValue("null") is NSNull)
+        XCTAssertTrue(ExtraParametersApplier.parseParameterValue("nil") is NSNull)
+        XCTAssertNil(ExtraParametersApplier.parseParameterValue(""))
+        XCTAssertNil(ExtraParametersApplier.parseParameterValue("   "))
+    }
+
+    // MARK: - parseParameterValue 结构化
+
+    func testParseParameterValueStructured() {
+        let object = ExtraParametersApplier.parseParameterValue(#"{"a":1,"b":"x"}"#) as? [String: Any]
+        XCTAssertEqual(object?["a"] as? Int, 1)
+        XCTAssertEqual(object?["b"] as? String, "x")
+
+        let array = ExtraParametersApplier.parseParameterValue("[1,2,3]") as? [Any]
+        XCTAssertEqual(array?.count, 3)
+        XCTAssertEqual(array?[0] as? Int, 1)
+    }
+
+    func testParseParameterValueInvalidJSONKeptAsString() {
+        // 以 { 或 [ 开头但解析失败：原样保留为字符串（明确、可测试，不会静默丢弃）。
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("{not valid}") as? String, "{not valid}")
+        XCTAssertEqual(ExtraParametersApplier.parseParameterValue("[unclosed") as? String, "[unclosed")
+    }
+
+    // MARK: - applyExtraParameters 点路径与冲突
+
+    func testApplyExtraParametersDotPath() {
+        let result = ExtraParametersApplier.applyExtraParameters(
+            ["limit.context": "8192", "limit.output": "4096"],
+            to: [:]
+        )
+        let limit = result["limit"] as? [String: Any]
+        XCTAssertEqual(limit?["context"] as? Int, 8192)
+        XCTAssertEqual(limit?["output"] as? Int, 4096)
+    }
+
+    func testApplyExtraParametersOverridesExistingEntry() {
+        let result = ExtraParametersApplier.applyExtraParameters(
+            ["temperature": "0.7", "reasoning.effort": "high"],
+            to: ["temperature": 1.0]
+        )
+        XCTAssertEqual(result["temperature"] as? Double, 0.7)
+        let reasoning = result["reasoning"] as? [String: Any]
+        XCTAssertEqual(reasoning?["effort"] as? String, "high")
+    }
+
+    func testApplyExtraParametersParentChildConflictDeterministic() {
+        // 父子路径冲突（"limit" 与 "limit.context"）：按 key 字典序排序后父路径先写、
+        // 子路径后写覆盖，结果确定，不依赖字典遍历顺序。最终 limit 是嵌套字典，子路径生效。
+        let result = ExtraParametersApplier.applyExtraParameters(
+            ["limit": "10", "limit.context": "8192"],
+            to: [:]
+        )
+        let limit = result["limit"] as? [String: Any]
+        XCTAssertNotNil(limit, "子路径应覆盖父路径标量，最终 limit 是嵌套字典")
+        XCTAssertEqual(limit?["context"] as? Int, 8192)
+    }
+
+    func testApplyExtraParametersSkipsEmptyValue() {
+        // 空值解析为 nil，apply 跳过该 key，不写入。
+        let result = ExtraParametersApplier.applyExtraParameters(
+            ["skip": "  ", "keep": "42"],
+            to: [:]
+        )
+        XCTAssertNil(result["skip"])
+        XCTAssertEqual(result["keep"] as? Int, 42)
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/JSONCEditorTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/JSONCEditorTests.swift
@@ -204,6 +204,35 @@ final class JSONCEditorTests: XCTestCase {
         XCTAssertEqualJSON(parse(out), target)
     }
 
+    func testRemovesLastStaleManagedKeyAndInsertsNewKeepingComments() {
+        let base = """
+        {
+          // 顶层注释
+          "model": "aiusage-old/m",
+          "provider": {
+            // provider 注释
+            "openrouter": { "npm": "@ai-sdk/openai-compatible" },
+            "aiusage-old": { "npm": "@ai-sdk/openai-compatible" }
+          }
+        }
+        """
+        let target: [String: Any] = [
+            "model": "aiusage-new/m",
+            "provider": [
+                "openrouter": ["npm": "@ai-sdk/openai-compatible"],
+                "aiusage-new": managedEntry("New", base: "https://n/v1"),
+            ],
+        ]
+        let result = JSONCEditor.merge(baseText: base, target: target)
+        XCTAssertNotNil(result, "删除最后一个受管键 + 新增受管键不应导致 merge 失败（重叠编辑）")
+        let out = result!
+        XCTAssertTrue(out.contains("// 顶层注释"), "顶层注释应保留")
+        XCTAssertTrue(out.contains("// provider 注释"), "provider 内注释应保留")
+        XCTAssertFalse(out.contains("aiusage-old"), "陈旧受管键应被移除")
+        XCTAssertTrue(out.contains("aiusage-new"), "新受管键应插入")
+        XCTAssertEqualJSON(parse(out), target)
+    }
+
     // MARK: - Safety / Fallback
 
     func testReturnsNilForUnparsableBase() {

--- a/QuotaBackend/Tests/QuotaBackendTests/JSONCEditorTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/JSONCEditorTests.swift
@@ -233,6 +233,35 @@ final class JSONCEditorTests: XCTestCase {
         XCTAssertEqualJSON(parse(out), target)
     }
 
+    func testRemovesConsecutiveStaleManagedKeysKeepingComments() {
+        let base = """
+        {
+          // 顶层注释
+          "model": "aiusage-node-a/m",
+          "provider": {
+            "openrouter": { "apiKey": "sk-or-xxx" },
+            "aiusage-node-a": { "baseURL": "http://a/v1" },
+            "aiusage-node-b": { "baseURL": "http://b/v1" },
+            // provider 注释
+          }
+        }
+        """
+        let target: [String: Any] = [
+            "provider": [
+                "openrouter": ["apiKey": "sk-or-xxx"],
+            ],
+        ]
+        let result = JSONCEditor.merge(baseText: base, target: target)
+        XCTAssertNotNil(result, "连续删除多个受管键不应导致 merge 失败（重叠编辑）")
+        let out = result!
+        XCTAssertTrue(out.contains("// 顶层注释"), "顶层注释应保留")
+        XCTAssertTrue(out.contains("// provider 注释"), "provider 内注释应保留")
+        XCTAssertFalse(out.contains("aiusage-node-a"), "受管键 a 应被移除")
+        XCTAssertFalse(out.contains("aiusage-node-b"), "受管键 b 应被移除")
+        XCTAssertTrue(out.contains("openrouter"), "保留成员应保留")
+        XCTAssertEqualJSON(parse(out), target)
+    }
+
     // MARK: - Safety / Fallback
 
     func testReturnsNilForUnparsableBase() {

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+@testable import QuotaBackend
+
+final class OpenCodeCallLedgerStoreTests: XCTestCase {
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-call-ledger-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeEntry(
+        partId: String,
+        dayKey: String = "2026-09-07",
+        kind: CallKind = .builtin,
+        name: String = "bash",
+        server: String? = nil,
+        success: Bool? = true,
+        durationMs: Double? = 100
+    ) -> OpenCodeCallLedgerEntry {
+        OpenCodeCallLedgerEntry(
+            partId: partId,
+            dayKey: dayKey,
+            kind: kind,
+            name: name,
+            server: server,
+            success: success,
+            durationMs: durationMs
+        )
+    }
+
+    func testMergeAccumulatesNewEntriesAcrossBatches() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2")], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_3")], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(Set(all.map(\.partId)), ["prt_1", "prt_2", "prt_3"])
+    }
+
+    func testMergeRetainsEntriesNotInLaterBatch() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(
+            newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2"), makeEntry(partId: "prt_3")],
+            completedFullHistory: false
+        )
+        // 第二批只扫到 prt_1（prt_2、prt_3 对应会话被删除），账本应保留它们。
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(Set(all.map(\.partId)), ["prt_1", "prt_2", "prt_3"])
+    }
+
+    func testMergeUpdatesExistingEntryWithoutDoubleCounting() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: false, durationMs: 50)], completedFullHistory: false)
+        // 同一条 part 状态从 running 更新为 completed：应覆盖旧值而非新增一条。
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: true, durationMs: 200)], completedFullHistory: false)
+
+        let all = store.allEntries()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all.first?.success, true)
+        XCTAssertEqual(all.first?.durationMs, 200)
+    }
+
+    func testAggregateGroupsByDayKey() {
+        let entries = [
+            makeEntry(partId: "prt_1", dayKey: "2026-09-06"),
+            makeEntry(partId: "prt_2", dayKey: "2026-09-07"),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+        XCTAssertEqual(Set(aggregated.map(\.dayKey)), ["2026-09-06", "2026-09-07"])
+    }
+
+    func testAggregateSumCountAndSignalsByKindAndName() {
+        let entries = [
+            makeEntry(partId: "prt_1", kind: .builtin, name: "bash", success: true, durationMs: 100),
+            makeEntry(partId: "prt_2", kind: .builtin, name: "bash", success: false, durationMs: 300),
+            makeEntry(partId: "prt_3", kind: .builtin, name: "read", success: nil, durationMs: nil),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+
+        let bash = aggregated.first { $0.name == "bash" }
+        XCTAssertEqual(bash?.count, 2)
+        XCTAssertEqual(bash?.outcomeKnownCount, 2)
+        XCTAssertEqual(bash?.successCount, 1)
+        XCTAssertEqual(bash?.durationSampleCount, 2)
+        XCTAssertEqual(bash?.durationMsTotal, 400)
+
+        let read = aggregated.first { $0.name == "read" }
+        XCTAssertEqual(read?.count, 1)
+        XCTAssertEqual(read?.outcomeKnownCount, 0)
+        XCTAssertEqual(read?.successCount, 0)
+        XCTAssertEqual(read?.durationSampleCount, 0)
+        XCTAssertEqual(read?.durationMsTotal, 0)
+    }
+
+    func testAggregateMCPKeepsServer() {
+        let entries = [
+            makeEntry(partId: "prt_1", kind: .mcp, name: "server/tool", server: "server"),
+        ]
+        let aggregated = OpenCodeCallLedgerStore.aggregate(entries)
+        XCTAssertEqual(aggregated.count, 1)
+        XCTAssertEqual(aggregated.first?.server, "server")
+        XCTAssertEqual(aggregated.first?.source, .opencode)
+    }
+
+    func testFullHistoryImportFlagPersists() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: true)
+        XCTAssertTrue(store.fullHistoryImported)
+
+        // 重新实例化（模拟重启）后标记仍在。
+        let reopened = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+        XCTAssertTrue(reopened.fullHistoryImported)
+    }
+
+    func testFullHistoryImportFlagSetOnEmptyMerge() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [], completedFullHistory: true)
+        XCTAssertTrue(store.fullHistoryImported)
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeCallLedgerStoreTests.swift
@@ -36,8 +36,8 @@ final class OpenCodeCallLedgerStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
 
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2")], completedFullHistory: false)
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_3")], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2")], scanSucceeded: true)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_3")], scanSucceeded: true)
 
         let all = store.allEntries()
         XCTAssertEqual(all.count, 3)
@@ -51,10 +51,10 @@ final class OpenCodeCallLedgerStoreTests: XCTestCase {
 
         _ = store.merge(
             newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2"), makeEntry(partId: "prt_3")],
-            completedFullHistory: false
+            scanSucceeded: true
         )
         // 第二批只扫到 prt_1（prt_2、prt_3 对应会话被删除），账本应保留它们。
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], scanSucceeded: true)
 
         let all = store.allEntries()
         XCTAssertEqual(all.count, 3)
@@ -66,9 +66,9 @@ final class OpenCodeCallLedgerStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
 
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: false, durationMs: 50)], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: false, durationMs: 50)], scanSucceeded: true)
         // 同一条 part 状态从 running 更新为 completed：应覆盖旧值而非新增一条。
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: true, durationMs: 200)], completedFullHistory: false)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1", success: true, durationMs: 200)], scanSucceeded: true)
 
         let all = store.allEntries()
         XCTAssertEqual(all.count, 1)
@@ -123,7 +123,7 @@ final class OpenCodeCallLedgerStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
 
-        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], completedFullHistory: true)
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], scanSucceeded: true)
         XCTAssertTrue(store.fullHistoryImported)
 
         // 重新实例化（模拟重启）后标记仍在。
@@ -136,7 +136,48 @@ final class OpenCodeCallLedgerStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
 
-        _ = store.merge(newEntries: [], completedFullHistory: true)
+        _ = store.merge(newEntries: [], scanSucceeded: true)
         XCTAssertTrue(store.fullHistoryImported)
+    }
+
+    func testScanFailureDoesNotMarkFullHistoryImport() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], scanSucceeded: false)
+        XCTAssertFalse(store.fullHistoryImported)
+        XCTAssertNil(store.lastSuccessfulScanDate)
+
+        let reopened = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+        XCTAssertFalse(reopened.fullHistoryImported)
+        XCTAssertNil(reopened.lastSuccessfulScanDate)
+    }
+
+    func testScanSuccessMarksFullHistoryAndAdvancesCursor() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1")], scanSucceeded: true)
+        XCTAssertTrue(store.fullHistoryImported)
+        XCTAssertNotNil(store.lastSuccessfulScanDate)
+
+        let reopened = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+        XCTAssertTrue(reopened.fullHistoryImported)
+        XCTAssertNotNil(reopened.lastSuccessfulScanDate)
+    }
+
+    func testScanFailureThenSuccessRecoversFullHistory() {
+        let tempRoot = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = OpenCodeCallLedgerStore(homeDirectory: tempRoot.path)
+
+        _ = store.merge(newEntries: [], scanSucceeded: false)
+        XCTAssertFalse(store.fullHistoryImported)
+
+        _ = store.merge(newEntries: [makeEntry(partId: "prt_1"), makeEntry(partId: "prt_2")], scanSucceeded: true)
+        XCTAssertTrue(store.fullHistoryImported)
+        XCTAssertEqual(store.allEntries().count, 2)
     }
 }

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -165,6 +165,62 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         XCTAssertEqual(entries.count, 2)
     }
 
+    func testLegacyArchiveMigrationPreservesDeletedSessionHistory() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        var legacyBucket = CodexAggregateBucket.empty
+        legacyBucket.record(row: CodexRow(
+            dayKey: "2026-01-01",
+            model: "anthropic/claude-sonnet",
+            inputTokens: 12,
+            cacheReadTokens: 0,
+            outputTokens: 0,
+            totalTokens: 12,
+            estimatedCostUsd: 0.01
+        ))
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], scanSucceeded: true)
+
+        var needsMigration = await store.needsLegacyArchiveMigration(homeDirectory: home.path)
+        XCTAssertTrue(needsMigration)
+        await store.migrateLegacyArchiveIfNeeded(
+            homeDirectory: home.path,
+            legacyDays: ["2026-01-01": legacyBucket],
+            todayKey: "2026-01-02"
+        )
+
+        let migrated = await store.legacyDays(homeDirectory: home.path)
+        XCTAssertEqual(migrated["2026-01-01"]?.totalTokens, 12)
+        XCTAssertEqual(migrated["2026-01-01"]?.estimatedCostUsd ?? 0, 0.01, accuracy: 0.0001)
+
+        needsMigration = await store.needsLegacyArchiveMigration(homeDirectory: home.path)
+        XCTAssertFalse(needsMigration)
+    }
+
+    func testLegacyArchiveMigrationSkipsToday() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        var pastBucket = CodexAggregateBucket.empty
+        pastBucket.record(row: CodexRow(dayKey: "2026-01-01", model: "m", inputTokens: 10, cacheReadTokens: 0, outputTokens: 0, totalTokens: 10, estimatedCostUsd: 0.01))
+        var todayBucket = CodexAggregateBucket.empty
+        todayBucket.record(row: CodexRow(dayKey: "2026-01-02", model: "m", inputTokens: 5, cacheReadTokens: 0, outputTokens: 0, totalTokens: 5, estimatedCostUsd: 0.005))
+
+        await store.migrateLegacyArchiveIfNeeded(
+            homeDirectory: home.path,
+            legacyDays: ["2026-01-01": pastBucket, "2026-01-02": todayBucket],
+            todayKey: "2026-01-02"
+        )
+
+        let migrated = await store.legacyDays(homeDirectory: home.path)
+        XCTAssertEqual(migrated.count, 1)
+        XCTAssertEqual(migrated["2026-01-01"]?.totalTokens, 10)
+        XCTAssertNil(migrated["2026-01-02"])
+    }
+
     // MARK: Helpers
 
     private func temporaryDirectory() -> URL {

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -245,7 +245,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         )
 
         XCTAssertEqual(residual["2026-01-01"]?.totalTokens, 40)
-        XCTAssertEqual(residual["2026-01-01"]?.inputTokens, 40)
+        XCTAssertEqual(residual["2026-01-01"]?.models["anthropic/claude-sonnet"]?.inputTokens, 40)
         XCTAssertEqual(residual["2026-01-01"]?.estimatedCostUsd ?? 0, 0.04, accuracy: 0.0001)
         XCTAssertEqual(residual["2026-01-01"]?.models["anthropic/claude-sonnet"]?.totalTokens, 40)
     }

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -188,10 +188,11 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         await store.migrateLegacyArchiveIfNeeded(
             homeDirectory: home.path,
             legacyDays: ["2026-01-01": legacyBucket],
+            ledgerSnapshotDays: [:],
             todayKey: "2026-01-02"
         )
 
-        let migrated = await store.legacyDays(homeDirectory: home.path)
+        let migrated = await store.legacyResidualDays(homeDirectory: home.path)
         XCTAssertEqual(migrated["2026-01-01"]?.totalTokens, 12)
         XCTAssertEqual(migrated["2026-01-01"]?.estimatedCostUsd ?? 0, 0.01, accuracy: 0.0001)
 
@@ -212,13 +213,84 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         await store.migrateLegacyArchiveIfNeeded(
             homeDirectory: home.path,
             legacyDays: ["2026-01-01": pastBucket, "2026-01-02": todayBucket],
+            ledgerSnapshotDays: [:],
             todayKey: "2026-01-02"
         )
 
-        let migrated = await store.legacyDays(homeDirectory: home.path)
+        let migrated = await store.legacyResidualDays(homeDirectory: home.path)
         XCTAssertEqual(migrated.count, 1)
         XCTAssertEqual(migrated["2026-01-01"]?.totalTokens, 10)
         XCTAssertNil(migrated["2026-01-02"])
+    }
+
+    func testResidualDaysPreservesPartialSameDayDeletion() {
+        // 旧归档某日 100 tokens，同日账本快照仅 60（部分会话已删）→ 残差 40，不丢已删会话的差额。
+        var legacyBucket = CodexAggregateBucket.empty
+        legacyBucket.record(row: CodexRow(
+            dayKey: "2026-01-01", model: "anthropic/claude-sonnet",
+            inputTokens: 100, cacheReadTokens: 0, outputTokens: 0,
+            totalTokens: 100, estimatedCostUsd: 0.10
+        ))
+        var ledgerBucket = CodexAggregateBucket.empty
+        ledgerBucket.record(row: CodexRow(
+            dayKey: "2026-01-01", model: "anthropic/claude-sonnet",
+            inputTokens: 60, cacheReadTokens: 0, outputTokens: 0,
+            totalTokens: 60, estimatedCostUsd: 0.06
+        ))
+
+        let residual = OpenCodeLedgerStore.residualDays(
+            legacyDays: ["2026-01-01": legacyBucket],
+            ledgerSnapshotDays: ["2026-01-01": ledgerBucket],
+            todayKey: "2026-01-02"
+        )
+
+        XCTAssertEqual(residual["2026-01-01"]?.totalTokens, 40)
+        XCTAssertEqual(residual["2026-01-01"]?.inputTokens, 40)
+        XCTAssertEqual(residual["2026-01-01"]?.estimatedCostUsd ?? 0, 0.04, accuracy: 0.0001)
+        XCTAssertEqual(residual["2026-01-01"]?.models["anthropic/claude-sonnet"]?.totalTokens, 40)
+    }
+
+    func testResidualDaysKeepsFullyDeletedDay() {
+        // 旧归档某日 100，账本快照该日无记录（会话完全删除）→ 残差 100，不丢。
+        var legacyBucket = CodexAggregateBucket.empty
+        legacyBucket.record(row: CodexRow(
+            dayKey: "2026-01-01", model: "anthropic/claude-sonnet",
+            inputTokens: 100, cacheReadTokens: 0, outputTokens: 0,
+            totalTokens: 100, estimatedCostUsd: 0.10
+        ))
+
+        let residual = OpenCodeLedgerStore.residualDays(
+            legacyDays: ["2026-01-01": legacyBucket],
+            ledgerSnapshotDays: [:],
+            todayKey: "2026-01-02"
+        )
+
+        XCTAssertEqual(residual["2026-01-01"]?.totalTokens, 100)
+        XCTAssertEqual(residual["2026-01-01"]?.usageRows, 1)
+    }
+
+    func testResidualDaysEmptyWhenFullyOverlapped() {
+        // 旧归档某日 60，账本快照同日 60（完全重叠）→ 无残差，避免重复计数。
+        var legacyBucket = CodexAggregateBucket.empty
+        legacyBucket.record(row: CodexRow(
+            dayKey: "2026-01-01", model: "anthropic/claude-sonnet",
+            inputTokens: 60, cacheReadTokens: 0, outputTokens: 0,
+            totalTokens: 60, estimatedCostUsd: 0.06
+        ))
+        var ledgerBucket = CodexAggregateBucket.empty
+        ledgerBucket.record(row: CodexRow(
+            dayKey: "2026-01-01", model: "anthropic/claude-sonnet",
+            inputTokens: 60, cacheReadTokens: 0, outputTokens: 0,
+            totalTokens: 60, estimatedCostUsd: 0.06
+        ))
+
+        let residual = OpenCodeLedgerStore.residualDays(
+            legacyDays: ["2026-01-01": legacyBucket],
+            ledgerSnapshotDays: ["2026-01-01": ledgerBucket],
+            todayKey: "2026-01-02"
+        )
+
+        XCTAssertNil(residual["2026-01-01"])
     }
 
     // MARK: Helpers

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import Foundation
+@testable import QuotaBackend
+
+final class OpenCodeLedgerStoreTests: XCTestCase {
+    func testMergeAccumulatesNewEntriesAcrossBatches() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        var days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 300)
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 2)
+
+        // 第二批：新 msg_3 + 更新 msg_2（同 id 覆盖）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+            entry(id: "msg_2", tokens: 250),
+        ], completedFullHistory: false)
+
+        days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 650)  // 100 + 250 + 300
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 3)
+    }
+
+    func testMergeRetainsEntriesNotInLaterBatch() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", tokens: 100),
+            entry(id: "msg_2", tokens: 200),
+        ], completedFullHistory: true)
+
+        // 模拟删除会话：第二批只含 msg_3（msg_1 已从 opencode.db 消失）
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_3", tokens: 300),
+        ], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 600)  // 100 + 200 + 300（msg_1 不丢）
+    }
+
+    func testMergeUpdatesExistingEntryWithoutDoubleCounting() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 100)], completedFullHistory: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 250)], completedFullHistory: false)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 250)  // 更新覆盖，不重复计数
+        XCTAssertEqual(days["2026-01-01"]?.usageRows, 1)
+    }
+
+    func testAggregateDaysGroupsByDayKey() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", tokens: 100),
+            entry(id: "msg_2", day: "2026-01-02", tokens: 200),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        XCTAssertEqual(days.count, 2)
+        XCTAssertEqual(days["2026-01-01"]?.totalTokens, 100)
+        XCTAssertEqual(days["2026-01-02"]?.totalTokens, 200)
+    }
+
+    func testAggregateDaysSumCostAndTokensByModel() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [
+            entry(id: "msg_1", day: "2026-01-01", model: "anthropic/sonnet", tokens: 100, cost: 0.01),
+            entry(id: "msg_2", day: "2026-01-01", model: "anthropic/sonnet", tokens: 200, cost: 0.02),
+            entry(id: "msg_3", day: "2026-01-01", model: "openai/gpt-5", tokens: 300, cost: 0.03),
+        ], completedFullHistory: true)
+
+        let days = await aggregatedDays(store, home: home.path)
+        let day = days["2026-01-01"]
+        XCTAssertEqual(day?.totalTokens, 600)
+        XCTAssertEqual(day?.estimatedCostUsd ?? 0, 0.06, accuracy: 0.0001)
+        XCTAssertEqual(day?.models.count, 2)
+        XCTAssertEqual(day?.models["anthropic/sonnet"]?.totalTokens, 300)
+        XCTAssertEqual(day?.models["openai/gpt-5"]?.totalTokens, 300)
+    }
+
+    func testFullHistoryImportFlagPersists() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        var shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertTrue(shouldImport)
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], completedFullHistory: true)
+
+        shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    func testFullHistoryImportFlagSetOnEmptyMerge() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        // 全量导入但 db 为空（无 assistant 消息）→ 仍标记已完成，避免每次重复全量扫描。
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], completedFullHistory: true)
+
+        let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+    }
+
+    // MARK: Helpers
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-ledger-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func aggregatedDays(_ store: OpenCodeLedgerStore, home: String) async -> [String: CodexAggregateBucket] {
+        let entries = await store.allEntries(homeDirectory: home)
+        return OpenCodeLedgerStore.aggregateDays(entries)
+    }
+
+    private func entry(
+        id: String,
+        day: String = "2026-01-01",
+        model: String = "anthropic/claude-sonnet",
+        tokens: Int = 100,
+        cost: Double = 0.01
+    ) -> OpenCodeLedgerEntry {
+        OpenCodeLedgerEntry(
+            messageId: id,
+            sessionId: "sess-1",
+            timeCreatedMillis: 1_700_000_000_000,
+            dayKey: day,
+            model: model,
+            inputTokens: tokens,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreateTokens: 0,
+            totalTokens: tokens,
+            estimatedCostUsd: cost
+        )
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLedgerStoreTests.swift
@@ -11,7 +11,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         _ = await store.merge(homeDirectory: home.path, newEntries: [
             entry(id: "msg_1", tokens: 100),
             entry(id: "msg_2", tokens: 200),
-        ], completedFullHistory: true)
+        ], scanSucceeded: true)
 
         var days = await aggregatedDays(store, home: home.path)
         XCTAssertEqual(days["2026-01-01"]?.totalTokens, 300)
@@ -21,7 +21,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         _ = await store.merge(homeDirectory: home.path, newEntries: [
             entry(id: "msg_3", tokens: 300),
             entry(id: "msg_2", tokens: 250),
-        ], completedFullHistory: false)
+        ], scanSucceeded: true)
 
         days = await aggregatedDays(store, home: home.path)
         XCTAssertEqual(days["2026-01-01"]?.totalTokens, 650)  // 100 + 250 + 300
@@ -36,12 +36,12 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         _ = await store.merge(homeDirectory: home.path, newEntries: [
             entry(id: "msg_1", tokens: 100),
             entry(id: "msg_2", tokens: 200),
-        ], completedFullHistory: true)
+        ], scanSucceeded: true)
 
         // 模拟删除会话：第二批只含 msg_3（msg_1 已从 opencode.db 消失）
         _ = await store.merge(homeDirectory: home.path, newEntries: [
             entry(id: "msg_3", tokens: 300),
-        ], completedFullHistory: false)
+        ], scanSucceeded: true)
 
         let days = await aggregatedDays(store, home: home.path)
         XCTAssertEqual(days["2026-01-01"]?.totalTokens, 600)  // 100 + 200 + 300（msg_1 不丢）
@@ -52,8 +52,8 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: home) }
         let store = OpenCodeLedgerStore()
 
-        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 100)], completedFullHistory: true)
-        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 250)], completedFullHistory: false)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 100)], scanSucceeded: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1", tokens: 250)], scanSucceeded: true)
 
         let days = await aggregatedDays(store, home: home.path)
         XCTAssertEqual(days["2026-01-01"]?.totalTokens, 250)  // 更新覆盖，不重复计数
@@ -68,7 +68,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         _ = await store.merge(homeDirectory: home.path, newEntries: [
             entry(id: "msg_1", day: "2026-01-01", tokens: 100),
             entry(id: "msg_2", day: "2026-01-02", tokens: 200),
-        ], completedFullHistory: true)
+        ], scanSucceeded: true)
 
         let days = await aggregatedDays(store, home: home.path)
         XCTAssertEqual(days.count, 2)
@@ -85,7 +85,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
             entry(id: "msg_1", day: "2026-01-01", model: "anthropic/sonnet", tokens: 100, cost: 0.01),
             entry(id: "msg_2", day: "2026-01-01", model: "anthropic/sonnet", tokens: 200, cost: 0.02),
             entry(id: "msg_3", day: "2026-01-01", model: "openai/gpt-5", tokens: 300, cost: 0.03),
-        ], completedFullHistory: true)
+        ], scanSucceeded: true)
 
         let days = await aggregatedDays(store, home: home.path)
         let day = days["2026-01-01"]
@@ -104,7 +104,7 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         var shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
         XCTAssertTrue(shouldImport)
 
-        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], completedFullHistory: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], scanSucceeded: true)
 
         shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
         XCTAssertFalse(shouldImport)
@@ -116,10 +116,53 @@ final class OpenCodeLedgerStoreTests: XCTestCase {
         let store = OpenCodeLedgerStore()
 
         // 全量导入但 db 为空（无 assistant 消息）→ 仍标记已完成，避免每次重复全量扫描。
-        _ = await store.merge(homeDirectory: home.path, newEntries: [], completedFullHistory: true)
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], scanSucceeded: true)
 
         let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
         XCTAssertFalse(shouldImport)
+    }
+
+    func testScanFailureDoesNotMarkFullHistoryImport() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], scanSucceeded: false)
+
+        let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertTrue(shouldImport)
+        let cursor = await store.lastSuccessfulScanMillis(homeDirectory: home.path)
+        XCTAssertNil(cursor)
+    }
+
+    func testScanSuccessMarksFullHistoryAndAdvancesCursor() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1")], scanSucceeded: true)
+
+        let shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+        let cursor = await store.lastSuccessfulScanMillis(homeDirectory: home.path)
+        XCTAssertNotNil(cursor)
+    }
+
+    func testScanFailureThenSuccessRecoversFullHistory() async {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = OpenCodeLedgerStore()
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [], scanSucceeded: false)
+        var shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertTrue(shouldImport)
+
+        _ = await store.merge(homeDirectory: home.path, newEntries: [entry(id: "msg_1"), entry(id: "msg_2")], scanSucceeded: true)
+        shouldImport = await store.consumeFullHistoryImportRequest(homeDirectory: home.path)
+        XCTAssertFalse(shouldImport)
+
+        let entries = await store.allEntries(homeDirectory: home.path)
+        XCTAssertEqual(entries.count, 2)
     }
 
     // MARK: Helpers

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
@@ -53,6 +53,52 @@ final class OpenCodeLegacyMigrationIntegrationTests: XCTestCase {
         XCTAssertEqual(second.extra["overall.totalTokens"]?.value as? Int, 110)
     }
 
+    // MARK: - 用量：数据目录暂不可用时旧归档回退、迁移保持 pending
+
+    func testPendingMigrationKeepsLegacyUsageVisibleWhenDataDirectoryUnavailable() async throws {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let utc = TimeZone(identifier: "UTC")!
+        let legacyDayMillis = utcMillis(year: 2026, month: 1, day: 10)
+
+        // 升级前旧归档：2026-01-10 = 12 tokens / $0.01。
+        try writeLegacyUsageArchive(home: home, dayKey: "2026-01-10", inputTokens: 12, cost: 0.01)
+
+        // OpenCode 数据目录暂不可用：XDG_DATA_HOME 指向无 opencode.db 的目录（home 下所有候选目录均无 db）。
+        let xdg = home.appendingPathComponent("xdg", isDirectory: true)
+        let provider = OpenCodeCostProvider(
+            homeDirectory: home.path,
+            timeZone: utc,
+            environment: ["XDG_DATA_HOME": xdg.path]
+        )
+
+        // 第一次 fetch：数据目录不可用，过去日回退旧归档展示 12（不报 no_usage_data），迁移保持 pending。
+        let first = try await provider.fetchUsage()
+        XCTAssertEqual(first.extra["overall.totalTokens"]?.value as? Int, 12)
+        XCTAssertTrue(await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path))
+        XCTAssertFalse(await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path))
+        XCTAssertTrue(await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path).isEmpty)
+
+        // 数据库恢复：opencode.db 含昨日 8 tokens（4 tokens 会话已删）→ 残差 12-8=4，展示 12 不重复不丢。
+        let dbDir = xdg.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dbDir, withIntermediateDirectories: true)
+        let dbPath = dbDir.appendingPathComponent("opencode.db").path
+        try executeSQL(
+            """
+            CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+            INSERT INTO message VALUES ('msg_1', 'sess_1', \(legacyDayMillis), '\(messageData(tokens: 8, cost: 0.01))');
+            """,
+            databasePath: dbPath
+        )
+
+        // 第二次 fetch：全量导入完成 + 残差迁移，展示 = 账本 8 + 残差 4 = 12。
+        let second = try await provider.fetchUsage()
+        XCTAssertEqual(second.extra["overall.totalTokens"]?.value as? Int, 12)
+        XCTAssertFalse(await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path))
+        XCTAssertTrue(await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path))
+        XCTAssertEqual(await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path)["2026-01-10"]?.totalTokens, 4)
+    }
+
     // MARK: - 调用：同日部分删除不丢、迁移后新增累加
 
     func testLegacyCallArchivePartialSameDayDeletionIsPreserved() async throws {

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import QuotaBackend
+
+// MARK: - OpenCode 旧归档残差迁移端到端回归
+// 覆盖 owner 评审阻塞项：按整日覆盖/让位会丢失「同日部分会话已删、只存在于旧归档」的记录。
+// 用真实旧归档 JSON 文件 + 真实 opencode.db（message/part 表）+ 真实 provider/engine 全链路验证，
+// 而非只测辅助函数：迁移后展示「当前账本 + 持久化残差」，迁移后新增记录继续正常累加。
+
+final class OpenCodeLegacyMigrationIntegrationTests: XCTestCase {
+
+    // MARK: - 用量：同日部分删除不丢、迁移后新增累加
+
+    func testLegacyUsageArchivePartialSameDayDeletionIsPreserved() async throws {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let utc = TimeZone(identifier: "UTC")!
+        let legacyDayMillis = utcMillis(year: 2026, month: 1, day: 10)
+
+        // 升级前旧归档：2026-01-10 = 100 tokens（其中 40 属于同日已删会话）。
+        try writeLegacyUsageArchive(home: home, dayKey: "2026-01-10", inputTokens: 100, cost: 0.10)
+
+        // 升级后 opencode.db：同日仅剩 60 tokens（部分会话已删）。
+        let xdg = home.appendingPathComponent("xdg", isDirectory: true)
+        let dbDir = xdg.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dbDir, withIntermediateDirectories: true)
+        let dbPath = dbDir.appendingPathComponent("opencode.db").path
+        try executeSQL(
+            """
+            CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+            INSERT INTO message VALUES ('msg_1', 'sess_1', \(legacyDayMillis), '\(messageData(tokens: 60, cost: 0.06))');
+            """,
+            databasePath: dbPath
+        )
+
+        let provider = OpenCodeCostProvider(
+            homeDirectory: home.path,
+            timeZone: utc,
+            environment: ["XDG_DATA_HOME": xdg.path]
+        )
+
+        // 第一次 fetch：触发残差迁移，展示 100 = 账本 60 + 残差 40（已删会话不丢）。
+        let first = try await provider.fetchUsage()
+        XCTAssertEqual(first.extra["overall.totalTokens"]?.value as? Int, 100)
+
+        // 迁移后新增 10 tokens（今天）→ 展示 110 = 100 + 今天新增 10。
+        try executeSQL(
+            "INSERT INTO message VALUES ('msg_2', 'sess_1', \(Int64(Date().timeIntervalSince1970 * 1000)), '\(messageData(tokens: 10, cost: 0.01))');",
+            databasePath: dbPath
+        )
+        let second = try await provider.fetchUsage()
+        XCTAssertEqual(second.extra["overall.totalTokens"]?.value as? Int, 110)
+    }
+
+    // MARK: - 调用：同日部分删除不丢、迁移后新增累加
+
+    func testLegacyCallArchivePartialSameDayDeletionIsPreserved() async throws {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let utc = TimeZone(identifier: "UTC")!
+        let legacyDayMillis = utcMillis(year: 2026, month: 1, day: 10)
+
+        // 升级前旧归档：2026-01-10 opencode bash=2/read=1。
+        let legacyBash = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "bash", server: nil,
+            dayKey: "2026-01-10", count: 2, outcomeKnownCount: 2, successCount: 2
+        )
+        let legacyRead = CallAnalyticsEntry(
+            source: .opencode, kind: .builtin, name: "read", server: nil,
+            dayKey: "2026-01-10", count: 1, outcomeKnownCount: 1, successCount: 1
+        )
+        try writeLegacyCallArchive(home: home, dayKey: "2026-01-10", entries: [legacyBash, legacyRead])
+
+        // 升级后 opencode.db：part 表同日仅剩 1 个 bash（read 会话已删）。
+        let xdg = home.appendingPathComponent("xdg", isDirectory: true)
+        let dbDir = xdg.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dbDir, withIntermediateDirectories: true)
+        let dbPath = dbDir.appendingPathComponent("opencode.db").path
+        try executeSQL(
+            """
+            CREATE TABLE part (id TEXT, time_created INTEGER, data TEXT);
+            INSERT INTO part VALUES ('part_1', \(legacyDayMillis), '\(partData(tool: "bash"))');
+            """,
+            databasePath: dbPath
+        )
+
+        let engine = CallAnalyticsEngine(
+            homeDirectory: home.path,
+            timeZone: utc,
+            environment: ["XDG_DATA_HOME": xdg.path]
+        )
+
+        // 第一次 computeSnapshot：触发残差迁移，bash=2/read=1（账本 bash=1 + 残差 bash=1/read=1）。
+        let first = await engine.computeSnapshot(rangeKey: "all", cutoff: nil)
+        XCTAssertEqual(totalCount(first.entries, name: "bash"), 2)
+        XCTAssertEqual(totalCount(first.entries, name: "read"), 1)
+
+        // 迁移后新增一次 bash（今天）→ bash=3/read=1。
+        try executeSQL(
+            "INSERT INTO part VALUES ('part_2', \(Int64(Date().timeIntervalSince1970 * 1000)), '\(partData(tool: "bash"))');",
+            databasePath: dbPath
+        )
+        let second = await engine.computeSnapshot(rangeKey: "all", cutoff: nil)
+        XCTAssertEqual(totalCount(second.entries, name: "bash"), 3)
+        XCTAssertEqual(totalCount(second.entries, name: "read"), 1)
+    }
+
+    // MARK: - Helpers
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("aiusage-opencode-legacy-migration-tests-\(UUID())", isDirectory: true)
+    }
+
+    private func utcMillis(year: Int, month: Int, day: Int, hour: Int = 12) -> Int64 {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        comps.hour = hour
+        let date = calendar.date(from: comps)!
+        return Int64(date.timeIntervalSince1970 * 1000)
+    }
+
+    private func messageData(tokens: Int, cost: Double) -> String {
+        let costStr = String(format: "%.4f", cost)
+        return "{\"role\":\"assistant\",\"providerID\":\"anthropic\",\"modelID\":\"claude-sonnet\",\"cost\":\(costStr),\"tokens\":{\"input\":\(tokens),\"output\":0,\"cache\":{\"read\":0,\"write\":0}}}"
+    }
+
+    private func partData(tool: String) -> String {
+        "{\"type\":\"tool\",\"tool\":\"\(tool)\",\"state\":{\"status\":\"completed\"}}"
+    }
+
+    private func executeSQL(_ sql: String, databasePath: String) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(databasePath, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
+            let message = db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed"
+            sqlite3_close(db)
+            throw ProviderError("db_open_failed", message)
+        }
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw ProviderError("db_exec_failed", message)
+        }
+    }
+
+    private func writeLegacyUsageArchive(home: URL, dayKey: String, inputTokens: Int, cost: Double) throws {
+        var archive = CodexUsageArchive(
+            version: 1, updatedAt: "", days: [:],
+            fullHistoryImportedAt: "2026-01-05T00:00:00Z"
+        )
+        var bucket = CodexAggregateBucket.empty
+        bucket.record(row: CodexRow(
+            dayKey: dayKey,
+            model: "anthropic/claude-sonnet",
+            inputTokens: inputTokens,
+            cacheReadTokens: 0,
+            outputTokens: 0,
+            totalTokens: inputTokens,
+            estimatedCostUsd: cost
+        ))
+        archive.days[dayKey] = bucket
+        let url = OpenCodeUsageArchiveStore.fileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(archive).write(to: url, options: .atomic)
+    }
+
+    private func writeLegacyCallArchive(home: URL, dayKey: String, entries: [CallAnalyticsEntry]) throws {
+        var archive = CallAnalyticsArchive(
+            version: 1, updatedAt: "", fullHistoryImportedAt: "2026-01-05T00:00:00Z", days: [:]
+        )
+        archive.days[dayKey] = CallAnalyticsDayBucket(entries: entries, agentInvocations: [])
+        let url = CallAnalyticsArchiveStore.fileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(archive).write(to: url, options: .atomic)
+    }
+
+    private func totalCount(_ entries: [CallAnalyticsEntry], name: String) -> Int {
+        entries.filter { $0.name == name }.reduce(0) { $0 + $1.count }
+    }
+}

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
@@ -105,6 +105,56 @@ final class OpenCodeLegacyMigrationIntegrationTests: XCTestCase {
         XCTAssertEqual(residualAfterRecovery["2026-01-10"]?.totalTokens, 4)
     }
 
+    // MARK: - 用量：数据库存在但查询失败时旧归档回退、扫描错误暂存
+
+    func testScanFailureKeepsLegacyUsageVisibleWhenDatabaseExistsButQueryFails() async throws {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let utc = TimeZone(identifier: "UTC")!
+        let legacyDayMillis = utcMillis(year: 2026, month: 1, day: 10)
+
+        // 升级前旧归档：2026-01-10 = 12 tokens。
+        try writeLegacyUsageArchive(home: home, dayKey: "2026-01-10", inputTokens: 12, cost: 0.01)
+
+        // opencode.db 存在但缺少 message 表 → fetchMessageRows 抛 db_query_failed（扫描失败但不提前退出）。
+        let xdg = home.appendingPathComponent("xdg", isDirectory: true)
+        let dbDir = xdg.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dbDir, withIntermediateDirectories: true)
+        let dbPath = dbDir.appendingPathComponent("opencode.db").path
+        try executeSQL("CREATE TABLE unrelated (id TEXT);", databasePath: dbPath)
+
+        let provider = OpenCodeCostProvider(
+            homeDirectory: home.path,
+            timeZone: utc,
+            environment: ["XDG_DATA_HOME": xdg.path]
+        )
+
+        // 第一次 fetch：扫描失败但旧归档有数据 → 展示 12，迁移 pending、full-history 未推进。
+        let first = try await provider.fetchUsage()
+        XCTAssertEqual(first.extra["overall.totalTokens"]?.value as? Int, 12)
+        let stillNeedsMigration = await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path)
+        XCTAssertTrue(stillNeedsMigration)
+        let importedAfterFirst = await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path)
+        XCTAssertFalse(importedAfterFirst)
+
+        // 修复数据库：建 message 表 + 昨日 8 tokens → 残差 12-8=4，展示 12 不重复不丢。
+        try executeSQL(
+            """
+            DROP TABLE unrelated;
+            CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+            INSERT INTO message VALUES ('msg_1', 'sess_1', \(legacyDayMillis), '\(messageData(tokens: 8, cost: 0.01))');
+            """,
+            databasePath: dbPath
+        )
+
+        let second = try await provider.fetchUsage()
+        XCTAssertEqual(second.extra["overall.totalTokens"]?.value as? Int, 12)
+        let importedAfterRecovery = await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path)
+        XCTAssertTrue(importedAfterRecovery)
+        let residualAfterRecovery = await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path)
+        XCTAssertEqual(residualAfterRecovery["2026-01-10"]?.totalTokens, 4)
+    }
+
     // MARK: - 调用：同日部分删除不丢、迁移后新增累加
 
     func testLegacyCallArchivePartialSameDayDeletionIsPreserved() async throws {

--- a/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
+++ b/QuotaBackend/Tests/QuotaBackendTests/OpenCodeLegacyMigrationIntegrationTests.swift
@@ -75,9 +75,12 @@ final class OpenCodeLegacyMigrationIntegrationTests: XCTestCase {
         // 第一次 fetch：数据目录不可用，过去日回退旧归档展示 12（不报 no_usage_data），迁移保持 pending。
         let first = try await provider.fetchUsage()
         XCTAssertEqual(first.extra["overall.totalTokens"]?.value as? Int, 12)
-        XCTAssertTrue(await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path))
-        XCTAssertFalse(await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path))
-        XCTAssertTrue(await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path).isEmpty)
+        let stillNeedsMigration = await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path)
+        XCTAssertTrue(stillNeedsMigration)
+        let importedAfterFirst = await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path)
+        XCTAssertFalse(importedAfterFirst)
+        let residualAfterFirst = await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path)
+        XCTAssertTrue(residualAfterFirst.isEmpty)
 
         // 数据库恢复：opencode.db 含昨日 8 tokens（4 tokens 会话已删）→ 残差 12-8=4，展示 12 不重复不丢。
         let dbDir = xdg.appendingPathComponent("opencode", isDirectory: true)
@@ -94,9 +97,12 @@ final class OpenCodeLegacyMigrationIntegrationTests: XCTestCase {
         // 第二次 fetch：全量导入完成 + 残差迁移，展示 = 账本 8 + 残差 4 = 12。
         let second = try await provider.fetchUsage()
         XCTAssertEqual(second.extra["overall.totalTokens"]?.value as? Int, 12)
-        XCTAssertFalse(await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path))
-        XCTAssertTrue(await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path))
-        XCTAssertEqual(await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path)["2026-01-10"]?.totalTokens, 4)
+        let needsMigrationAfterRecovery = await OpenCodeCostProvider.ledger.needsLegacyArchiveMigration(homeDirectory: home.path)
+        XCTAssertFalse(needsMigrationAfterRecovery)
+        let importedAfterRecovery = await OpenCodeCostProvider.ledger.isFullHistoryImported(homeDirectory: home.path)
+        XCTAssertTrue(importedAfterRecovery)
+        let residualAfterRecovery = await OpenCodeCostProvider.ledger.legacyResidualDays(homeDirectory: home.path)
+        XCTAssertEqual(residualAfterRecovery["2026-01-10"]?.totalTokens, 4)
     }
 
     // MARK: - 调用：同日部分删除不丢、迁移后新增累加


### PR DESCRIPTION
## 概述

本 PR 统一收口四个功能的交付，包含并取代 #71、#72、#73：

- **#71 用量账本**：OpenCode 用量数据自存储，删除会话后统计不丢。
- **#72 多节点激活**：多节点激活 + JSONC 受管层健壮性修复。
- **#73 按模型追加参数**：按模型追加任意参数（issue #69）。
- **#74 调用分析后台同步**：调用分析后台定时同步 + 重新打开界面强制刷新。

## 合并前修复（owner 收口清单）

- **A. 单节点停用事务一致性**：`OpenCodeNodeStore.deactivate` 改为先恢复/重写配置成功再提交激活集合与停代理，多节点一次性停用，失败时原状态不变。
- **B. 账本同步失败重试 + 跨日补采**：账本新增 `lastSuccessfulScanMillis` 游标与 `fullHistoryImportedAt` 分离；`merge` 参数改为 `scanSucceeded`，扫描成功才推进游标与全量标记；OpenCode 源 scan cutoff 独立并带 24h 重叠补采，不再固定扫今天；展示层 OpenCode 从账本聚合取，archive 只负责 Claude/Codex。
- **C. 参数解析聚焦测试**：`parseParameterValue`/`applyExtraParameters` 抽到 `ExtraParametersApplier` 并补 8 个聚焦测试（标量/结构化/无效 JSON/点路径/父子路径冲突确定性）。
- **附加修复**：①多节点默认模型被 cpa 节点覆盖 → 通用配置卡片增加「默认模型节点」下拉框；②opencode.jsonc 注释偶现丢失 → JSONCEditor 删除尾键与插入重叠导致 merge 失败 fallback 丢注释。

## 回归测试对应

- 首次数据库查询失败不标记完成 → `testScanFailureDoesNotMarkFullHistoryImport`（#74/#71 账本）
- 23:xx 记录进账本跨日补采 → `CallAnalyticsEngineTests`（openCodeScanCutoff 补采窗口）+ 已有 `testAggregateGroupsByDayKey`
- 停用操作不改变激活状态 / 多节点状态一致 → 修复 A（AIUsage target 无单元测试 target，由 CI 编译 + 人工验证覆盖）
- JSONC 注释保持 → `testRemovesLastStaleManagedKeyAndInsertsNewKeepingComments`

## 验证

QuotaBackend swift build 通过；CI 编译 + 测试。
